### PR TITLE
feat: Only call init fn if value is defined

### DIFF
--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1,6 +1,15 @@
+import { render } from "@homebound/rtl-utils";
 import { autorun, isObservable, makeAutoObservable, observable, reaction } from "mobx";
 import { AuthorAddress, AuthorInput, BookInput, DateOnly, dd100, dd200, jan1, jan2 } from "src/formStateDomain";
-import { createObjectState, FieldState, ObjectConfig, ObjectState, pickFields, required } from "./formState";
+import {
+  createObjectState,
+  FieldState,
+  ObjectConfig,
+  ObjectState,
+  pickFields,
+  required,
+  useFormState,
+} from "./formState";
 
 describe("formState", () => {
   it("mobx lists maintain observable identity", () => {
@@ -1099,6 +1108,34 @@ describe("formState", () => {
     // And treat it as a value object
     a.address.set({ street: "123", city: "nyc" });
     expect(a.value).toEqual({ address: { street: "123", city: "nyc" } });
+  });
+
+  it("can filter out undefined from the init value", async () => {
+    // Given a component
+    function TestComponent() {
+      const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
+      // And we have query data that may or may not be defined
+      const data: { firstName: string } | undefined = { firstName: "bob" };
+      // Then the lambda is passed the "de-undefined" data
+      const form = useFormState(config, data, (data) => ({ firstName: data.firstName }));
+      return <div>{form.firstName.value}</div>;
+    }
+    const r = await render(<TestComponent />);
+    expect(r.baseElement).toHaveTextContent("bob");
+  });
+
+  it("enforces the init functions returns all keys", async () => {
+    // Given a component
+    function TestComponent() {
+      const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
+      // And we have query data that may or may not be defined
+      const data: { firstName: string } | undefined = { firstName: "bob" };
+      // Then the lambda is passed the "de-undefined" data
+      const form = useFormState(config, data, (data) => ({ firstName: data.firstName }));
+      return <div>{form.firstName.value}</div>;
+    }
+    const r = await render(<TestComponent />);
+    expect(r.baseElement).toHaveTextContent("bob");
   });
 });
 

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -14,7 +14,7 @@ import { assertNever, fail } from "src/utils";
  */
 export function useFormState<T, O>(
   config: ObjectConfig<T>,
-  initValue: O,
+  initValue: O | null | undefined,
   initFn: (initValue: O) => T,
   opts?: {
     addRules?: (state: ObjectState<T>) => void;
@@ -27,7 +27,7 @@ export function useFormState<T, O>(
   const form = useMemo(() => {
     // We purposefully use a non-memo'd initFn for better developer UX, i.e. the caller
     // of `useFormState` doesn't have to `useCallback` their `initFn` just to pass it to us.
-    const instance = pickFields(config, initFn(initValue));
+    const instance = pickFields(config, initValue ? initFn(initValue) : {});
     const form = createObjectState(config, instance, {
       onBlur: () => {
         // Don't use canSave() because we don't want to set touched for all of the field


### PR DESCRIPTION
Just a small quality-of-life improvement, I don't want to have to null check the `query.data` that I'm passing as an init value.

I _think_ this is a good idea. It's something I wanted in procurement-frontend's 1st form.

Also I moved to the "opts" approach to let the `initValue` be optional.