### PR TITLE
feat: Refactor to opts, more flexible init BREAKING CHANGE

### DIFF
--- a/src/FormStateApp.tsx
+++ b/src/FormStateApp.tsx
@@ -3,28 +3,25 @@ import { FieldState, ObjectConfig, required, useFormState } from "src/formState"
 import { AuthorInput } from "src/formStateDomain";
 
 export function FormStateApp() {
-  const formState = useFormState(
-    formConfig,
-    undefined,
+  const formState = useFormState({
+    config: formConfig,
     // Simulate getting the initial form state back from a server call
-    () => ({
+    initFn: () => ({
       firstName: "a1",
       books: [...Array(2)].map((_, i) => ({
         title: `b${i}`,
         classification: { number: `10${i + 1}`, category: `Test Category ${i}` },
       })),
     }),
-    {
-      addRules(state) {
-        state.lastName.rules.push(() => {
-          return state.firstName.value === state.lastName.value ? "Last name cannot equal first name" : undefined;
-        });
-      },
-      autoSave() {
-        console.log("saving", formState.changedValue);
-      },
+    addRules(state) {
+      state.lastName.rules.push(() => {
+        return state.firstName.value === state.lastName.value ? "Last name cannot equal first name" : undefined;
+      });
     },
-  );
+    autoSave() {
+      console.log("saving", formState.changedValue);
+    },
+  });
 
   return (
     <Observer>

--- a/src/FormStateApp.tsx
+++ b/src/FormStateApp.tsx
@@ -6,13 +6,13 @@ export function FormStateApp() {
   const formState = useFormState({
     config: formConfig,
     // Simulate getting the initial form state back from a server call
-    initFn: () => ({
+    init: {
       firstName: "a1",
       books: [...Array(2)].map((_, i) => ({
         title: `b${i}`,
         classification: { number: `10${i + 1}`, category: `Test Category ${i}` },
       })),
-    }),
+    },
     addRules(state) {
       state.lastName.rules.push(() => {
         return state.firstName.value === state.lastName.value ? "Last name cannot equal first name" : undefined;

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1133,7 +1133,7 @@ describe("formState", () => {
       // Then the lambda is passed the "de-undefined" data
       const form = useFormState({
         config,
-        initValue: data,
+        initInput: data,
         initFn: (data) => ({ firstName: data.firstName }),
       });
       return <div>{form.firstName.value}</div>;
@@ -1151,7 +1151,7 @@ describe("formState", () => {
       // Then the lambda is passed the "de-undefined" data
       const form = useFormState({
         config,
-        initValue: data,
+        initInput: data,
         initFn: (data) => ({ firstName: data.firstName }),
         initValueIfUndefined: { firstName: "fred" },
       });

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1,6 +1,15 @@
+import { render } from "@homebound/rtl-utils";
 import { autorun, isObservable, makeAutoObservable, observable, reaction } from "mobx";
 import { AuthorAddress, AuthorInput, BookInput, DateOnly, dd100, dd200, jan1, jan2 } from "src/formStateDomain";
-import { createObjectState, FieldState, ObjectConfig, ObjectState, pickFields, required } from "./formState";
+import {
+  createObjectState,
+  FieldState,
+  ObjectConfig,
+  ObjectState,
+  pickFields,
+  required,
+  useFormState,
+} from "./formState";
 
 describe("formState", () => {
   it("mobx lists maintain observable identity", () => {
@@ -1113,6 +1122,20 @@ describe("formState", () => {
     // And treat it as a value object
     a.address.set({ street: "123", city: "nyc" });
     expect(a.value).toEqual({ address: { street: "123", city: "nyc" } });
+  });
+
+  it("can filter out undefined from the init value", async () => {
+    // Given a component
+    function TestComponent() {
+      const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
+      // And we have query data that may or may not be defined
+      const data: { firstName: string } | undefined = { firstName: "bob" };
+      // Then the lambda is passed the "de-undefined" data
+      const form = useFormState({ config, initValue: data, initFn: (data) => ({ firstName: data.firstName }) });
+      return <div>{form.firstName.value}</div>;
+    }
+    const r = await render(<TestComponent />);
+    expect(r.baseElement).toHaveTextContent("bob");
   });
 });
 

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -575,20 +575,6 @@ describe("formState", () => {
     });
   });
 
-  it("readOnly field should not throw error onBlur", () => {
-    // Given a readOnly formState with a string field
-    const formState = createAuthorInputState({ firstName: "fn" });
-    formState.readOnly = true;
-
-    // When interacting with a string form field (focus and blur)
-    formState.firstName.focus();
-
-    // Then expect no errors to be thrown
-    expect(() => {
-      formState.firstName.blur();
-    }).not.toThrow();
-  });
-
   it("maintain field readOnly state when form is readOnly", () => {
     // Given a formState
     const formState = createObjectState<BookInput>({ title: { type: "value", rules: [required], readOnly: true } }, {});
@@ -1124,12 +1110,30 @@ describe("formState", () => {
     expect(a.value).toEqual({ address: { street: "123", city: "nyc" } });
   });
 
-  it("can filter out undefined from the init value", async () => {
+  it("calls initFn even if initInput is undefined", async () => {
     // Given a component
     function TestComponent() {
       const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
       // And we have query data that may or may not be defined
-      const data: { firstName: string } | undefined = { firstName: "bob" };
+      // const data: { firstName: string } | undefined = Math.random() > 0 ? { firstName: "bob" } : undefined;
+      // Then // the lambda is passed the "de-undefined" data
+      const form = useFormState({
+        config,
+        initFn: () => ({ firstName: "bob" }),
+      });
+      return <div>{form.firstName.value}</div>;
+    }
+    const r = await render(<TestComponent />);
+    expect(r.baseElement).toHaveTextContent("bob");
+  });
+
+  it("calls initFn even if initInput is undefined", async () => {
+    // Given a component
+    function TestComponent() {
+      const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
+      // And we have query data that may or may not be defined
+      // const data: { firstName: string } | undefined = Math.random() > 0 ? { firstName: "bob" } : undefined;
+      const data: { firstName: string } =  { firstName: "bob" };
       // Then the lambda is passed the "de-undefined" data
       const form = useFormState({
         config,
@@ -1140,43 +1144,6 @@ describe("formState", () => {
     }
     const r = await render(<TestComponent />);
     expect(r.baseElement).toHaveTextContent("bob");
-  });
-
-  it("provides empty hash as initial value if init value is undefined", async () => {
-    // Given a component
-    function TestComponent() {
-      const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
-      // And we have query data that may or may not be defined
-      const data: { firstName: string } | undefined = undefined as any;
-      // Then the lambda is passed the "de-undefined" data
-      const form = useFormState({
-        config,
-        initInput: data,
-        initFn: (data) => ({ firstName: data.firstName }),
-      });
-      return <div>{form.firstName.value}</div>;
-    }
-    const r = await render(<TestComponent />);
-    expect(r.baseElement).toHaveTextContent("");
-  });
-
-  it("can use a custom initial value if init value is undefined", async () => {
-    // Given a component
-    function TestComponent() {
-      const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
-      // And we have query data that may or may not be defined
-      const data: { firstName: string } | undefined = undefined as any;
-      // Then the lambda is passed the "de-undefined" data
-      const form = useFormState({
-        config,
-        initInput: data,
-        initFn: (data) => ({ firstName: data.firstName }),
-        initValueIfUndefined: { firstName: "fred" },
-      });
-      return <div>{form.firstName.value}</div>;
-    }
-    const r = await render(<TestComponent />);
-    expect(r.baseElement).toHaveTextContent("fred");
   });
 });
 

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1131,11 +1131,34 @@ describe("formState", () => {
       // And we have query data that may or may not be defined
       const data: { firstName: string } | undefined = { firstName: "bob" };
       // Then the lambda is passed the "de-undefined" data
-      const form = useFormState({ config, initValue: data, initFn: (data) => ({ firstName: data.firstName }) });
+      const form = useFormState({
+        config,
+        initValue: data,
+        initFn: (data) => ({ firstName: data.firstName }),
+      });
       return <div>{form.firstName.value}</div>;
     }
     const r = await render(<TestComponent />);
     expect(r.baseElement).toHaveTextContent("bob");
+  });
+
+  it("can use a custom initial value if init value is undefined", async () => {
+    // Given a component
+    function TestComponent() {
+      const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
+      // And we have query data that may or may not be defined
+      const data: { firstName: string } | undefined = undefined as any;
+      // Then the lambda is passed the "de-undefined" data
+      const form = useFormState({
+        config,
+        initValue: data,
+        initFn: (data) => ({ firstName: data.firstName }),
+        initValueIfUndefined: { firstName: "fred" },
+      });
+      return <div>{form.firstName.value}</div>;
+    }
+    const r = await render(<TestComponent />);
+    expect(r.baseElement).toHaveTextContent("fred");
   });
 });
 

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1110,16 +1110,18 @@ describe("formState", () => {
     expect(a.value).toEqual({ address: { street: "123", city: "nyc" } });
   });
 
-  it("calls initFn even if initInput is undefined", async () => {
+  it("calls initIfExisting if input data is defined", async () => {
     // Given a component
     function TestComponent() {
-      const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
+      type FormValue = Pick<AuthorInput, "firstName">;
+      const config: ObjectConfig<FormValue> = { firstName: { type: "value" } };
       // And we have query data that may or may not be defined
-      // const data: { firstName: string } | undefined = Math.random() > 0 ? { firstName: "bob" } : undefined;
-      // Then // the lambda is passed the "de-undefined" data
+      const data: { firstName: string } | undefined = Math.random() >= 0 ? { firstName: "bob" } : undefined;
+      // Then the lambda is passed the "de-undefined" data
       const form = useFormState({
         config,
-        initFn: () => ({ firstName: "bob" }),
+        initInput: data,
+        initIfExisting: (d) => ({ firstName: d.firstName }),
       });
       return <div>{form.firstName.value}</div>;
     }
@@ -1127,23 +1129,24 @@ describe("formState", () => {
     expect(r.baseElement).toHaveTextContent("bob");
   });
 
-  it("calls initFn even if initInput is undefined", async () => {
+  it("uses initIfNew if initInput is undefined", async () => {
     // Given a component
     function TestComponent() {
-      const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
+      type FormValue = Pick<AuthorInput, "firstName">;
+      const config: ObjectConfig<FormValue> = { firstName: { type: "value" } };
       // And we have query data that may or may not be defined
-      // const data: { firstName: string } | undefined = Math.random() > 0 ? { firstName: "bob" } : undefined;
-      const data: { firstName: string } =  { firstName: "bob" };
+      const data: { firstName: string | undefined | null } | undefined =
+        Math.random() >= 0 ? undefined : { firstName: "bob" };
       // Then the lambda is passed the "de-undefined" data
       const form = useFormState({
         config,
         initInput: data,
-        initFn: (data) => ({ firstName: data.firstName }),
+        initIfExisting: (data) => ({ ...data }),
       });
       return <div>{form.firstName.value}</div>;
     }
     const r = await render(<TestComponent />);
-    expect(r.baseElement).toHaveTextContent("bob");
+    expect(r.baseElement.textContent).toEqual("");
   });
 });
 

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1142,6 +1142,24 @@ describe("formState", () => {
     expect(r.baseElement).toHaveTextContent("bob");
   });
 
+  it("provides empty hash as initial value if init value is undefined", async () => {
+    // Given a component
+    function TestComponent() {
+      const config: ObjectConfig<AuthorInput> = { firstName: { type: "value" } };
+      // And we have query data that may or may not be defined
+      const data: { firstName: string } | undefined = undefined as any;
+      // Then the lambda is passed the "de-undefined" data
+      const form = useFormState({
+        config,
+        initInput: data,
+        initFn: (data) => ({ firstName: data.firstName }),
+      });
+      return <div>{form.firstName.value}</div>;
+    }
+    const r = await render(<TestComponent />);
+    expect(r.baseElement).toHaveTextContent("");
+  });
+
   it("can use a custom initial value if init value is undefined", async () => {
     // Given a component
     function TestComponent() {

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -14,15 +14,16 @@ export type UseFormStateOpts<T, I> = {
    * User's can either:
    *
    * - Provide no initial value (don't set `init` at all)
-   * - Provide an initial value that already matches the form type `T` (see `init: ...`)
+   * - Provide an initial value that already matches the form type `T` (i.e. set `init: data`)
    * - Provide an initial value from an object that _almost_ matches the form type `T`,
    *   but needs to be mapped from it's input type `I` to the form type
-   *   (pass `init: { input: ..., map: (input) => ...}.
+   *   (i.e. set `init: { input: data, map: (data) => ...}`).
    *
-   * The value of using the 3rd option is that we a) internally `useMemo` on the identity of the
+   * The value of using the 3rd option is that: a) we internally `useMemo` on the identity of the
    * `init.input` (i.e. a response from an Apollo hook) and don't require the `map` function
-   * to have a stable identity, and also b) will null-check/undefined-check `init.input` and
-   * only call `init.map` if it's set, otherwise we'll use `init.ifDefined` or `{}`.
+   * to have a stable identity, and also b) we will null-check/undefined-check `init.input` and
+   * only call `init.map` if it's set, otherwise we'll use `init.ifDefined` or `{}`, saving you
+   * from having to null check within your `init.map` function.
    */
   init?:
     | T
@@ -41,8 +42,9 @@ export type UseFormStateOpts<T, I> = {
 
   /** Whether the form should be read only, when changed it won't re-create the whole form. */
   readOnly?: boolean;
+
   /**
-   * Fired when the form should auto-save, i.e. after a) blur + b) all fields are valid.
+   * Fired when the form should auto-save, i.e. after a) blur and b) all fields are valid.
    *
    * Does not need to be stable/useMemo'd.
    */

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -6,23 +6,43 @@ import { assertNever, fail } from "src/utils";
 
 /**
  * Creates a formState instance for editing in a form.
- *
- * @param opts.config the form configuration, should be module-level const or useMemo'd
- * @param opts.initValue the initial value from GraphQL, i.e. the Author that we're editing, should be useMemo'd
- * @param opts.initFn a function to adapt the Author "output" object to the form's object.
- * @param opts.addRules a hook to add cross-field rules that can't be declared in `config`
- * @param opts.autoSave invoked when the form should auto-save (i.e. on blur of any changed field)
  */
 export function useFormState<T, O>(opts: {
+  /** The form configuration, should be a module-level const or useMemo'd. */
   config: ObjectConfig<T>;
+  /**
+   * The form's initial value, i.e. from GraphQL the Author that we're editing, should be stable/useMemo'd.
+   *
+   * If not provided, then `initFn` will always be called.
+   * If provided, then `initFn` will only be called when this is defined.
+   */
   initValue?: O | null | undefined;
+  /**
+   * Provides the form's initial value, as adapted from the `initValue`.
+   *
+   * If not you've passed the `initValue` key, this will always be called.
+   * If you have passed the `initValue` key, this will get the de-optional'd `initValue` (i.e. so that
+   * you don't have to do `undefined` checks while waiting for a GQL query to load).
+   */
   initFn: (initValue: O) => T;
+  /** The initial value to use if you pass `initValue`, but it's undefined. Defaults to `{}`. */
+  initValueIfUndefined?: T;
+  /**
+   * A hook to add custom, cross-field validation rules that can be difficult to setup directly in the config DSL.
+   *
+   * Does not need to be stable/useMemo'd.
+   */
   addRules?: (state: ObjectState<T>) => void;
+  /** Whether the form should be read only, when changed it won't re-create the whole form. */
   readOnly?: boolean;
-  /** Fired when the form should auto-save, i.e. after a) blur + b) all fields are valid. */
+  /**
+   * Fired when the form should auto-save, i.e. after a) blur + b) all fields are valid.
+   *
+   * Does not need to be stable/useMemo'd.
+   */
   autoSave?: (state: ObjectState<T>) => void;
 }): ObjectState<T> {
-  const { config, initFn, addRules, readOnly = false, autoSave, initValue } = opts;
+  const { config, initFn, addRules, readOnly = false, autoSave, initValue, initValueIfUndefined } = opts;
   const form = useMemo(() => {
     // We purposefully use a non-memo'd initFn for better developer UX, i.e. the caller
     // of `useFormState` doesn't have to `useCallback` their `initFn` just to pass it to us.
@@ -30,7 +50,10 @@ export function useFormState<T, O>(opts: {
     // If they didn't pass initValue, always call initFn to let them provide the default.
     // Otherwise, if they did pass initValue, make sure it's not undefined before calling initFn,
     // just to help them avoid a `if !undefined` check on the init value.
-    const instance = pickFields(config, !passedInitValue ? initFn({} as any) : initValue ? initFn(initValue) : {});
+    const instance = pickFields(
+      config,
+      !passedInitValue ? initFn({} as any) : initValue ? initFn(initValue) : initValueIfUndefined,
+    );
     const form = createObjectState(config, instance, {
       onBlur: () => {
         // Don't use canSave() because we don't want to set touched for all of the field

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -51,7 +51,7 @@ export function useFormState<T, O>(opts: {
    */
   autoSave?: (state: ObjectState<T>) => void;
 }): ObjectState<T> {
-  const { config, initFn, addRules, readOnly = false, autoSave, initInput, initValueIfUndefined } = opts;
+  const { config, initFn, addRules, readOnly = false, autoSave, initInput, initValueIfUndefined = {} } = opts;
   const form = useMemo(() => {
     // We purposefully use a non-memo'd initFn for better developer UX, i.e. the caller
     // of `useFormState` doesn't have to `useCallback` their `initFn` just to pass it to us.

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -10,29 +10,38 @@ import { assertNever, fail } from "src/utils";
 export function useFormState<T, O>(opts: {
   /** The form configuration, should be a module-level const or useMemo'd. */
   config: ObjectConfig<T>;
+
   /**
-   * The form's initial value, i.e. from GraphQL the Author that we're editing, should be stable/useMemo'd.
+   * Provides the form's initial value, as adapted from the `initInput` (if provided).
+   *
+   * If you've not passed the `initInput` key, this function will still be called, just once,
+   * to provide the initial value (i.e. you don't need to useMemo/useCallback the function).
+   *
+   * If you have passed the `initInput` key, this function will be called with the de-optional'd
+   * `initInput` (i.e. so that you don't have to do `undefined` checks while waiting for a GQL
+   * query to load), and then re-called anytime the identity of `initInput` changes.
+   */
+  initFn: (initInput: O) => T;
+
+  /**
+   * The initFn's input value, i.e. from GraphQL the Author that we're editing, so that you can
+   * adapt it to the form's value. Should be stable/useMemo'd.
    *
    * If not provided, then `initFn` will always be called.
    * If provided, then `initFn` will only be called when this is defined.
    */
   initInput?: O | null | undefined;
-  /**
-   * Provides the form's initial value, as adapted from the `initInput`.
-   *
-   * If not you've passed the `initInput` key, this will always be called.
-   * If you have passed the `initInput` key, this will get the de-optional'd `initInput` (i.e. so that
-   * you don't have to do `undefined` checks while waiting for a GQL query to load).
-   */
-  initFn: (initInput: O) => T;
-  /** The initial value to use if you pass `initInput`, but it's undefined. Defaults to `{}`. */
+
+  /** The initial value to use if you pass `initInput`, but it's `undefined`. Defaults to `{}`. */
   initValueIfUndefined?: T;
+
   /**
    * A hook to add custom, cross-field validation rules that can be difficult to setup directly in the config DSL.
    *
    * Does not need to be stable/useMemo'd.
    */
   addRules?: (state: ObjectState<T>) => void;
+
   /** Whether the form should be read only, when changed it won't re-create the whole form. */
   readOnly?: boolean;
   /**

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -16,16 +16,16 @@ export function useFormState<T, O>(opts: {
    * If not provided, then `initFn` will always be called.
    * If provided, then `initFn` will only be called when this is defined.
    */
-  initValue?: O | null | undefined;
+  initInput?: O | null | undefined;
   /**
-   * Provides the form's initial value, as adapted from the `initValue`.
+   * Provides the form's initial value, as adapted from the `initInput`.
    *
-   * If not you've passed the `initValue` key, this will always be called.
-   * If you have passed the `initValue` key, this will get the de-optional'd `initValue` (i.e. so that
+   * If not you've passed the `initInput` key, this will always be called.
+   * If you have passed the `initInput` key, this will get the de-optional'd `initInput` (i.e. so that
    * you don't have to do `undefined` checks while waiting for a GQL query to load).
    */
-  initFn: (initValue: O) => T;
-  /** The initial value to use if you pass `initValue`, but it's undefined. Defaults to `{}`. */
+  initFn: (initInput: O) => T;
+  /** The initial value to use if you pass `initInput`, but it's undefined. Defaults to `{}`. */
   initValueIfUndefined?: T;
   /**
    * A hook to add custom, cross-field validation rules that can be difficult to setup directly in the config DSL.
@@ -42,17 +42,17 @@ export function useFormState<T, O>(opts: {
    */
   autoSave?: (state: ObjectState<T>) => void;
 }): ObjectState<T> {
-  const { config, initFn, addRules, readOnly = false, autoSave, initValue, initValueIfUndefined } = opts;
+  const { config, initFn, addRules, readOnly = false, autoSave, initInput, initValueIfUndefined } = opts;
   const form = useMemo(() => {
     // We purposefully use a non-memo'd initFn for better developer UX, i.e. the caller
     // of `useFormState` doesn't have to `useCallback` their `initFn` just to pass it to us.
-    const passedInitValue = "initValue" in opts;
-    // If they didn't pass initValue, always call initFn to let them provide the default.
-    // Otherwise, if they did pass initValue, make sure it's not undefined before calling initFn,
+    const passedInitValue = "initInput" in opts;
+    // If they didn't pass initInput, always call initFn to let them provide the default.
+    // Otherwise, if they did pass initInput, make sure it's not undefined before calling initFn,
     // just to help them avoid a `if !undefined` check on the init value.
     const instance = pickFields(
       config,
-      !passedInitValue ? initFn({} as any) : initValue ? initFn(initValue) : initValueIfUndefined,
+      !passedInitValue ? initFn({} as any) : initInput ? initFn(initInput) : initValueIfUndefined,
     );
     const form = createObjectState(config, instance, {
       onBlur: () => {
@@ -70,7 +70,7 @@ export function useFormState<T, O>(opts: {
 
     return form;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [config, ...(Array.isArray(initValue) ? initValue : [initValue])]);
+  }, [config, ...(Array.isArray(initInput) ? initInput : [initInput])]);
 
   // Use useEffect so that we don't touch the form.init proxy during a render
   useEffect(() => {


### PR DESCRIPTION
Just a small quality-of-life improvement, I don't want to have to null check the `query.data` that I'm passing as an init value.

I _think_ this is a good idea. It's something I wanted in procurement-frontend's 1st form.

Also I moved to the "opts" approach to let the `initValue` be optional, per what @khalidwilliams ran into a few days ago.