### PR TITLE
fix: Remove init from useMemo when it's not the input/map pair.

### DIFF
--- a/src/formState.ts
+++ b/src/formState.ts
@@ -84,7 +84,8 @@ export function useFormState<T, I>(opts: UseFormStateOpts<T, I>): ObjectState<T>
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     config,
-    ...(init && "input" in init && "map" in init ? (Array.isArray(init.input) ? init.input : [init.input]) : [init]),
+    // If they're using init.input, useMemo on it, otherwise let the identity of init be unstable
+    ...(init && "input" in init && "map" in init ? [init.input] : []),
   ]);
 
   // Use useEffect so that we don't touch the form.init proxy during a render


### PR DESCRIPTION
This was my intent with the new API, but it wasn't covered by a test, so had a bug.