### PR TITLE
fix: Allow reset while read only.

### DIFF
--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -471,6 +471,44 @@ describe("formState", () => {
     expect(a1.touched).toBeFalsy();
   });
 
+  it("resets values even if read only", () => {
+    // Given a form state
+    const a1 = createAuthorInputState({
+      firstName: "a1",
+      lastName: "aL1",
+      books: [
+        { title: "b1", classification: dd100 },
+        { title: "b2", classification: dd100 },
+      ],
+    });
+    // And some values have been changed
+    expect(a1.dirty).toBeFalsy();
+    a1.firstName.set("a2");
+    a1.firstName.touched = true;
+    a1.lastName.set("aL2");
+    a1.books.rows[0].set({ title: "b2" });
+    a1.books.rows[1].set({ title: "bb2" });
+    a1.books.add({ title: "b3" });
+    expect(a1.books.touched).toEqual(true);
+    expect(a1.dirty).toBeTruthy();
+    // And the "readOnly=true" operation has "beat" the reset operation
+    a1.readOnly = true;
+    // When we reset
+    a1.reset();
+    // Then it still works
+    expect(a1.firstName.value).toBe("a1");
+    expect(a1.firstName.touched).toBeFalsy();
+    expect(a1.lastName.value).toBe("aL1");
+    expect(a1.books.rows.length).toBe(2);
+    expect(a1.books.touched).toBe(false);
+    expect(a1.books.rows[0].title.value).toBe("b1");
+    expect(a1.books.rows[0].title.dirty).toBe(false);
+    expect(a1.books.rows[0].title.touched).toBe(false);
+    expect(a1.books.rows[1].title.value).toBe("b2");
+    expect(a1.dirty).toBeFalsy();
+    expect(a1.touched).toBeFalsy();
+  });
+
   it("saves values into _originalState", () => {
     const a1 = createAuthorInputState({
       firstName: "a1",
@@ -578,7 +616,7 @@ describe("formState", () => {
     a1.readOnly = true;
     fields.forEach((f) => expect(f.readOnly).toBeTruthy());
     fields.forEach((f) => {
-      expect(() => f.set(null!)).toThrow("Currently readOnly");
+      expect(() => f.set(null!)).toThrow("is currently readOnly");
     });
   });
 

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -439,7 +439,7 @@ function newObjectState<T, P = any>(
     // Accepts new values in bulk, i.e. when setting the form initial state from the backend.
     set(value: T) {
       if (this.readOnly) {
-        throw new Error("Currently readOnly");
+        throw new Error(`${key || "formState"} is currently readOnly`);
       }
       getFields(this).forEach((field) => {
         if (field.key in value && (!field.dirty || !(field as any)._focused)) {
@@ -616,9 +616,9 @@ function newValueFieldState<T, K extends keyof T>(
       onBlur();
     },
 
-    set(value: V | null | undefined) {
-      if (this.readOnly) {
-        throw new Error("Currently readOnly");
+    set(value: V | null | undefined, opts: { resetting?: boolean } = {}) {
+      if (this.readOnly && !opts.resetting) {
+        throw new Error(`${key} is currently readOnly`);
       }
 
       // If the user has deleted/emptied a value that was originally set, keep it as `null`
@@ -634,11 +634,8 @@ function newValueFieldState<T, K extends keyof T>(
     },
 
     reset() {
-      // We check !this.readOnly b/c set will blow up, but maybe we should pass
-      // an internal override to allow it anyway? Currently this is failing when
-      // using a `isReadOnlyKey` has made an entity read-only.
-      if (!computed && !this.readOnly) {
-        this.set(this.originalValue);
+      if (!computed) {
+        this.set(this.originalValue, { resetting: true });
       }
       this.touched = false;
     },
@@ -790,9 +787,9 @@ function newListFieldState<T, K extends keyof T, U>(
       onBlur();
     },
 
-    set(values: U[]) {
-      if (this.readOnly) {
-        throw new Error("Currently readOnly");
+    set(values: U[], opts: { resetting?: boolean } = {}) {
+      if (this.readOnly && !opts.resetting) {
+        throw new Error(`${key} is currently readOnly`);
       }
       // We should be passed values that are non-proxies.
       parentInstance[key] = (values.map((value) => {
@@ -831,7 +828,7 @@ function newListFieldState<T, K extends keyof T, U>(
 
     reset() {
       if (originalCopy) {
-        this.set(originalCopy);
+        this.set(originalCopy, { resetting: true });
         this.rows.forEach((r) => r.reset());
       }
     },


### PR DESCRIPTION
@DeanGilewicz noticed an existing bug in blueprint where:

* User hits cancel
* The query string `?edit=1` is unset
* The form state is put read only
* The navigation prompt says "are you sure?"
* User says yes, I'm sure leave me out of edit mode
* The form actions calls `formState.reset` to throw away WIP changes
* `formState.set` would either "do nothing" (for value fields) or "blow up" (for list fields)

Now we let the reset just happen, b/c we assume it's an "admin operation" that is known to be okay, and not literally, say, a form field mutating a read-only form state, which we still want to avoid/prevent.