### PR TITLE
fix: Don't include empty subobjects in changedValue.

### DIFF
--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -972,6 +972,18 @@ describe("formState", () => {
     });
   });
 
+  it("changedValue skips unchanged nested fields", () => {
+    // Given a new author with an address object
+    const formState = createObjectState(authorWithAddressConfig, {
+      firstName: "f",
+      // And nothing is in the address
+      address: {},
+    });
+    // Then we don't include an empty address in the output,
+    // because this might trigger creating a throw-away entity
+    expect(formState.changedValue).toEqual({ firstName: "f" });
+  });
+
   it("can return only changed list fields", () => {
     // Given an author with some books
     const formState = createObjectState(authorWithBooksConfig, {

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -972,12 +972,24 @@ describe("formState", () => {
     });
   });
 
-  it("changedValue skips unchanged nested fields", () => {
+  it("changedValue skips empty nested fields", () => {
     // Given a new author with an address object
     const formState = createObjectState(authorWithAddressConfig, {
       firstName: "f",
       // And nothing is in the address
       address: {},
+    });
+    // Then we don't include an empty address in the output,
+    // because this might trigger creating a throw-away entity
+    expect(formState.changedValue).toEqual({ firstName: "f" });
+  });
+
+  it("changedValue skips effectively empty nested fields", () => {
+    // Given a new author with an address object
+    const formState = createObjectState(authorWithAddressConfig, {
+      firstName: "f",
+      // And only undefined keys are in the address
+      address: { city: undefined },
     });
     // Then we don't include an empty address in the output,
     // because this might trigger creating a throw-away entity

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -472,7 +472,7 @@ function newObjectState<T, P = any>(
             // Unless they're undefined anyway
             f.value !== undefined &&
             // And unless they're empty sub-objects
-            !(f.value instanceof Object && Object.entries(f.value).length === 0))
+            !(f.value instanceof Object && Object.entries(f.changedValue).length === 0))
         ) {
           result[f.key] = f.changedValue;
         }

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -464,14 +464,22 @@ function newObjectState<T, P = any>(
     get changedValue() {
       const result: any = {};
       getFields(this).forEach((f) => {
-        // If the called used useFormState.ifUndefined, the key may not look dirty even though we're new
-        if (f.dirty || this.isNewEntity) {
+        if (
+          f.dirty ||
+          // If the caller used useFormState.ifUndefined to provide some default values, then those keys may not
+          // look dirty, but if we're new we should include them anyway.
+          (this.isNewEntity &&
+            // Unless they're undefined anyway
+            f.value !== undefined &&
+            // And unless they're empty sub-objects
+            !(f.value instanceof Object && Object.entries(f.value).length === 0))
+        ) {
           result[f.key] = f.changedValue;
         }
       });
       // Ensure we always have the id for updates to work
       const idField = getFields(this).find((f) => (f as any)._isIdKey);
-      if (idField) {
+      if (idField && idField.value !== undefined) {
         result[idField.key] = idField.value;
       }
       return result;


### PR DESCRIPTION
This restores the behavior of "save a new contact" where if no address fields are filled in, then the address key isn't included in the payload.