### PR TITLE
feat: Keep work-in-progress form values after cache refreshes.

### DIFF
--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1384,18 +1384,20 @@ describe("formState", () => {
       const config: ObjectConfig<FormValue> = authorWithAddressAndBooksConfig;
       // And we have two sets of data
       const data1 = {
+        id: "a:1",
         firstName: "f1",
         lastName: "l1",
-        address: { street: "s1", city: "c1" },
+        address: { id: "address:1", street: "s1", city: "c1" },
         books: [
           { id: "b:1", title: "a1" },
           { id: "b:2", title: "b1" },
         ],
       };
       const data2 = {
+        id: "a:1",
         firstName: "f2",
         lastName: "l2",
-        address: { street: "s2", city: "c2" },
+        address: { id: "address:1", street: "s2", city: "c2" },
         books: [
           { id: "b:1", title: "a2" },
           { id: "b:2", title: "b2" },
@@ -1426,6 +1428,7 @@ describe("formState", () => {
               <div data-testid="booksLength">{form.books.rows.length}</div>
               <button data-testid="makeLocalChanges" onClick={makeLocalChanges} />
               <button data-testid="refreshData" onClick={refreshData} />
+              <div data-testid="changedValue">{JSON.stringify(form.changedValue)}</div>
             </div>
           )}
         </Observer>
@@ -1444,6 +1447,12 @@ describe("formState", () => {
     expect(r.firstName().textContent).toEqual("local");
     expect(r.street().textContent).toEqual("local");
     expect(r.title1().textContent).toEqual("local");
+    expect(JSON.parse(r.changedValue().textContent)).toEqual({
+      id: "a:1",
+      address: { id: "address:1", street: "local" },
+      books: [{ id: "b:1", title: "local" }, { id: "b:2" }],
+      firstName: "local",
+    });
 
     // And when the new query is ran i.e. due to a cache refresh
     click(r.refreshData);
@@ -1457,6 +1466,12 @@ describe("formState", () => {
     expect(r.city().textContent).toEqual("c2");
     expect(r.title2().textContent).toEqual("b2");
     expect(r.booksLength().textContent).toEqual("3");
+    expect(JSON.parse(r.changedValue().textContent)).toEqual({
+      id: "a:1",
+      address: { id: "address:1", street: "local" },
+      books: [{ id: "b:1", title: "local" }, { id: "b:2" }, { id: "b:3" }],
+      firstName: "local",
+    });
   });
 });
 
@@ -1521,6 +1536,7 @@ const authorWithAddressAndBooksConfig: ObjectConfig<AuthorInput> = {
   address: {
     type: "object",
     config: {
+      id: { type: "value" },
       street: { type: "value", rules: [required] },
       city: { type: "value" },
     },

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -682,6 +682,10 @@ function newValueFieldState<T, K extends keyof T>(
       // Set the value on our parent object
       parentInstance[key] = newValue!;
       _tick.value++;
+
+      if (opts.refreshing) {
+        this.originalValue = newValue;
+      }
     },
 
     reset() {

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -91,8 +91,8 @@ export function useFormState<T, I>(opts: UseFormStateOpts<T, I>): ObjectState<T>
       firstRunRef.current = false;
       return;
     }
-    // Use any because `{ refresh: true }` is private
-    (form as any).set(initValue(config, init), { refresh: true });
+    // Use any because `{ refreshing: true }` is private
+    (form as any).set(initValue(config, init), { refreshing: true });
   }, [
     form,
     // If they're using init.input, useMemo on it, otherwise let the identity of init be unstable
@@ -450,7 +450,7 @@ function newObjectState<T, P = any>(
     },
 
     // Accepts new values in bulk, i.e. when setting the form initial state from the backend.
-    set(value: T, opts: { resetting?: boolean } = {}) {
+    set(value: T, opts: { refreshing?: boolean } = {}) {
       if (this.readOnly) {
         throw new Error(`${key || "formState"} is currently readOnly`);
       }
@@ -648,12 +648,12 @@ function newValueFieldState<T, K extends keyof T>(
       onBlur();
     },
 
-    set(value: V | null | undefined, opts: { resetting?: boolean; refresh?: true } = {}) {
+    set(value: V | null | undefined, opts: { resetting?: boolean; refreshing?: true } = {}) {
       if (this.readOnly && !opts.resetting) {
         throw new Error(`${key} is currently readOnly`);
       }
 
-      if (opts.refresh && this.dirty) {
+      if (opts.refreshing && this.dirty) {
         // Ignore refreshed values if we're already dirty
         return;
       }
@@ -824,7 +824,7 @@ function newListFieldState<T, K extends keyof T, U>(
       onBlur();
     },
 
-    set(values: U[], opts: { resetting?: boolean; refresh?: boolean } = {}) {
+    set(values: U[], opts: { resetting?: boolean; refreshing?: boolean } = {}) {
       if (this.readOnly && !opts.resetting) {
         throw new Error(`${key} is currently readOnly`);
       }

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -79,12 +79,12 @@ export function useFormState<T, I>(opts: UseFormStateOpts<T, I>): ObjectState<T>
       firstRunRef.current = true;
       return form;
     },
-    // For this useMemo, we never re-run so that we can have a stable `form` identity across query refreshes.
+    // For this useMemo, we (almost) never re-run so that we can have a stable `form` identity across query refreshes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [config],
   );
 
-  // For this useMemo, we re-run any time input changes
+  // For this useMemo, we re-run any time input changes (could be a useEffect, but running immediately seems better)
   useMemo(() => {
     // Ignore the 1st run b/c our 1st useMemo already initialized `form` with the current `init` value
     if (firstRunRef.current) {
@@ -94,6 +94,7 @@ export function useFormState<T, I>(opts: UseFormStateOpts<T, I>): ObjectState<T>
     // Use any because `{ refresh: true }` is private
     (form as any).set(initValue(config, init), { refresh: true });
   }, [
+    form,
     // If they're using init.input, useMemo on it, otherwise let the identity of init be unstable
     ...(init && "input" in init && "map" in init ? (Array.isArray(init.input) ? init.input : [init.input]) : []),
   ]);

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -91,8 +91,7 @@ export function useFormState<T, I>(opts: UseFormStateOpts<T, I>): ObjectState<T>
       firstRunRef.current = false;
       return;
     }
-    // Use any because `{ refreshing: true }` is private
-    (form as any).set(initValue(config, init), { refreshing: true });
+    (form as ObjectStateInternal<any>).set(initValue(config, init), { refreshing: true });
   }, [
     form,
     // If they're using init.input, useMemo on it, otherwise let the identity of init be unstable


### PR DESCRIPTION
This should fix the issue Jonnathan noticed where having WIP values in a form will get lost if the Apollo cache rerenders.

We use the `field.dirty` flag to accept any new values (i.e. you probably want to see the latest values from the server), unless you have local changes, we'll keep your local changes.