### PR TITLE
fix: Fix rerendering w/new data when read only.

### DIFF
--- a/src/formState.ts
+++ b/src/formState.ts
@@ -466,7 +466,7 @@ function newObjectState<T, P = any>(
 
     // Accepts new values in bulk, i.e. when setting the form initial state from the backend.
     set(value: T, opts: SetOpts = {}) {
-      if (this.readOnly) {
+      if (this.readOnly && !opts.resetting && !opts.refreshing) {
         throw new Error(`${key || "formState"} is currently readOnly`);
       }
       getFields(this).forEach((field) => {
@@ -663,7 +663,7 @@ function newValueFieldState<T, K extends keyof T>(
     },
 
     set(value: V | null | undefined, opts: { resetting?: boolean; refreshing?: true } = {}) {
-      if (this.readOnly && !opts.resetting) {
+      if (this.readOnly && !opts.resetting && !opts.refreshing) {
         throw new Error(`${key} is currently readOnly`);
       }
 
@@ -843,7 +843,7 @@ function newListFieldState<T, K extends keyof T, U>(
     },
 
     set(values: U[], opts: SetOpts = {}) {
-      if (this.readOnly && !opts.resetting) {
+      if (this.readOnly && !opts.resetting && !opts.refreshing) {
         throw new Error(`${key} is currently readOnly`);
       }
       // We should be passed values that are non-proxies.


### PR DESCRIPTION
Before the previous PR, this just worked b/c when new data came in we re-created the whole form state from scratch.

Now that we keep the old form state around, and call `.set` with the new data, the `.set` needs to not blow up when its read-only.