### PR TITLE
fix: Fix focused fields ignoring incoming values.

### DIFF
--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1087,7 +1087,7 @@ describe("formState", () => {
     // And they have wip edits
     formState.firstName.set("ff");
     // When a mutation result sets both firstName and lastName
-    formState.set({ firstName: "f2", lastName: "l2" });
+    (formState as any).set({ firstName: "f2", lastName: "l2" }, { refreshing: true });
     // Then we don't overwrite the user's WIP work
     expect(formState.firstName.value).toEqual("ff");
     expect(formState.lastName.value).toEqual("l2");
@@ -1101,7 +1101,7 @@ describe("formState", () => {
     // Given first name is focused, but has not changed
     formState.firstName.focus();
     // When a mutation result sets both firstName and lastName
-    formState.set({ firstName: "f2", lastName: "l2" });
+    (formState as any).set({ firstName: "f2", lastName: "l2" }, { refreshing: true });
     // Then we do update the value
     expect(formState.firstName.value).toEqual("f2");
   });

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -476,7 +476,7 @@ function newObjectState<T, P = any>(
         throw new Error(`${key || "formState"} is currently readOnly`);
       }
       getFields(this).forEach((field) => {
-        if (field.key in value && (!field.dirty || !field._focused)) {
+        if (field.key in value) {
           field.set((value as any)[field.key], opts);
         }
       });
@@ -673,8 +673,10 @@ function newValueFieldState<T, K extends keyof T>(
         throw new Error(`${key} is currently readOnly`);
       }
 
-      if (opts.refreshing && this.dirty && value !== this.value) {
-        // Ignore refreshed values if we're already dirty
+      if (opts.refreshing && this.dirty && this.value !== value) {
+        // Ignore incoming values if we have changes (this.dirty) unless our latest change (this.value)
+        // matches the incoming value (value), b/c if it does we should accept it and reset originalValue
+        // so that we're not longer dirty.
         return;
       } else if (computed && (opts.resetting || opts.refreshing)) {
         // Computeds can't be either reset or refreshed


### PR DESCRIPTION
When a new mutation result came in, our 1st attempt at "don't loose user's WIP changes" (which was focused based) would ignore it.

We actually want to accept incoming values _if they match our current value_, so that fields are made clean.

Our 2nd attempt code (the `opts.refreshing`-aware code in `ValueField.set`) already knew about this, but the old code in `ObjectField.set` didn't so just remove the 1st attempt and use the 2nd attempt.

Fwiw it looks like we're basically not using "is focused" for anything at the moment, so could probably remove it? 