### PR TITLE
fix: Make ListField.value observable.

### DIFF
--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -146,6 +146,20 @@ describe("formState", () => {
     expect(ticks).toEqual(3);
   });
 
+  it("list value can observe changes", () => {
+    const b1: BookInput = { title: "t1" };
+    const a1: AuthorInput = { firstName: "a1", books: [b1] };
+    const state = createAuthorInputState(a1);
+    let books: any;
+    let ticks = 0;
+    autorun(() => {
+      books = state.books.value;
+      ticks++;
+    });
+    state.books.add({ title: "t2" }, 0);
+    expect(ticks).toEqual(2);
+  });
+
   it("maintains unknown fields", () => {
     // Given the form is not directly editing id fields
     const config: ObjectConfig<AuthorInput> = {

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -940,7 +940,10 @@ function newListFieldState<T, K extends keyof T, U>(
     },
   };
 
-  return list as any;
+  return makeAutoObservable(list, {
+    // See other makeAutoObservable comment
+    value: computed({ equals: () => false }),
+  }) as any;
 }
 
 function isNotUndefined<T>(value: T | undefined): value is T {


### PR DESCRIPTION
Previously b/c the identity of the list did not change, mobx caching
would kick-in and stop the notification.

We already had this `computed false` override for the core
formState.value, but weren't using it for child values.