### PR TITLE
feat: Use incremental mode if op/delete/remove key exists.

### DIFF
--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1131,6 +1131,43 @@ describe("formState", () => {
     });
   });
 
+  it("uses the op key as a hint to use incremental list behavior", () => {
+    // Given an author
+    const formState = createObjectState<AuthorInput>(
+      {
+        id: { type: "value" },
+        // And the books collection not explicitly marked as incremental
+        books: {
+          type: "list",
+          config: {
+            id: { type: "value" },
+            title: { type: "value", rules: [required] },
+            // But it does have an op key
+            op: { type: "value" },
+          },
+        },
+      },
+      {
+        id: "a:1",
+        firstName: "f",
+        books: [
+          // And the books start out as included
+          { id: "b:1", title: "t1", op: "include" },
+          { id: "b:2", title: "t2", op: "include" },
+        ],
+      },
+    );
+    // And initially nothing is changed
+    expect(formState.changedValue).toEqual({ id: "a:1" });
+    // When we delete the 1st book
+    formState.books.rows[0].op.value = "delete";
+    // Then only the 1st book is included
+    expect(formState.changedValue).toEqual({
+      id: "a:1",
+      books: [{ id: "b:1", op: "delete" }],
+    });
+  });
+
   it("can observe value changes", () => {
     const formState = createObjectState(authorWithBooksConfig, { firstName: "f" });
     let ticks = 0;

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -773,9 +773,13 @@ function newListFieldState<T, K extends keyof T, U>(
 
     get changedValue() {
       const result = [] as any;
-      const pushAll = listConfig.update !== "incremental";
+      const incremental =
+        listConfig.update === "incremental" ||
+        // Implicitly enable incremental mode if we see an op key
+        (listConfig.update === undefined &&
+          Object.entries(listConfig.config).some(([key]) => key === "op" || key === "delete" || key === "remove"));
       this.rows.forEach((r) => {
-        if (pushAll || r.dirty) {
+        if (!incremental || r.dirty) {
           result.push(r.changedValue);
         }
       });

--- a/src/formStateDomain.ts
+++ b/src/formStateDomain.ts
@@ -34,6 +34,7 @@ export interface BookInput {
   classification?: DeweyDecimalClassification;
   delete?: boolean | null | undefined;
   isPublished?: boolean;
+  op?: "include" | "delete" | "remove";
 }
 
 export interface DeweyDecimalClassification {


### PR DESCRIPTION
User's could already request incremental behavior, but it was easy to forget / not realize that feature was even available, so now we do it for free/automatically when we notice a form configured with one of our incremental-behavior op/delete/remove keys.