### PR TITLE
fix: Make getObjectState stable.

### DIFF
--- a/src/useFormStates.ts
+++ b/src/useFormStates.ts
@@ -1,32 +1,57 @@
-import { useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { createObjectState, ObjectConfig, ObjectState, ObjectStateInternal } from "src/formState";
 import { initValue } from "src/utils";
 
 export type ObjectStateCache<T, I> = Record<string, [ObjectState<T>, I]>;
 
 type UseFormStatesOpts<T, I> = {
+  /**
+   * The config to use for each form state.
+   *
+   * Should be stable/useMemo'd.
+   */
   config: ObjectConfig<T>;
 
-  /** Fired for each individual `ObjectState` when it's had a value change. */
+  /**
+   * Fired for each individual `ObjectState` when it's had a value change.
+   *
+   * Does not need to be stable/useMemo'd.
+   */
   autoSave?: (state: ObjectState<T>) => Promise<void>;
 
   /**
    * A hook to add custom, cross-field validation rules that can be difficult to setup directly in the config DSL.
    *
+   * This will be called once-per `ObjectState` instance, and so is effectively a `useEffect` hook with
+   * a `[config, objectState]` dependency.
+   *
    * Does not need to be stable/useMemo'd.
    */
   addRules?: (state: ObjectState<T>) => void;
 
-  /** Given an input to `getObjectState`, returns the identity value that we'll cache that value's form state on. */
+  /**
+   * Given an input to `getObjectState`, returns the identity value that we'll cache that value's form state on.
+   *
+   * Does not need to be stable/useMemo'd.
+   */
   getId: (v: I) => string;
 
-  /** Maps an input to `getObjectState` to the actual form shape `T`. */
+  /**
+   * Maps an input to `getObjectState` to the actual form shape `T`.
+   *
+   * Does not need to be stable/useMemo'd.
+   */
   map?: (input: Exclude<I, null | undefined>) => T;
 };
 
 export function useFormStates<T, I>(opts: UseFormStatesOpts<T, I>): { getObjectState: (input: I) => ObjectState<T> } {
   const { config, autoSave, getId, map, addRules } = opts;
-  const objectStateCache = useMemo<ObjectStateCache<T, I>>(() => ({}), [config]);
+  const objectStateCache = useMemo<ObjectStateCache<T, I>>(
+    () => ({}),
+    // Force resetting the cache if config changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [config],
+  );
   // Keep track of ObjectStates that triggered auto-save when a save was already in progress.
   const pendingAutoSaves = useRef<ObjectState<T>[]>([]);
 
@@ -54,8 +79,8 @@ export function useFormStates<T, I>(opts: UseFormStatesOpts<T, I>): { getObjectS
     }
   }
 
-  return {
-    getObjectState: (input) => {
+  const getObjectState = useCallback(
+    (input: I) => {
       const existing = objectStateCache[getId(input)];
       let form = existing?.[0];
 
@@ -78,7 +103,12 @@ export function useFormStates<T, I>(opts: UseFormStatesOpts<T, I>): { getObjectS
 
       return form;
     },
-  };
+    // Allow the user to not stable-ize getId, map, addRules, and autoSave
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [objectStateCache, config],
+  );
+
+  return { getObjectState };
 }
 
 // If the user's autoSave hook makes some last-minute `.set` calls to sneak


### PR DESCRIPTION
So that it can be used as a dependency for things like a `useMemo`-d `createColumns`.