### PR TITLE
feat: Rename getObjectState to getFormState.

### DIFF
--- a/src/useFormStates.test.tsx
+++ b/src/useFormStates.test.tsx
@@ -15,7 +15,7 @@ describe("useFormStates", () => {
     }
     function TestComponent() {
       const config: ObjectConfig<FormValue> = { id: { type: "value" }, firstName: { type: "value" } };
-      const { getObjectState } = useFormStates<FormValue, FormValue>({
+      const { getFormState } = useFormStates<FormValue, FormValue>({
         config,
         autoSave,
         getId: (o) => o.id!,
@@ -23,7 +23,7 @@ describe("useFormStates", () => {
 
       return (
         <div>
-          <ChildComponent os={getObjectState({ id: "a:1", firstName: "Brandon" })} />
+          <ChildComponent os={getFormState({ id: "a:1", firstName: "Brandon" })} />
         </div>
       );
     }
@@ -37,13 +37,13 @@ describe("useFormStates", () => {
     type FormValue = Pick<AuthorInput, "id" | "firstName">;
     const config: ObjectConfig<FormValue> = { id: { type: "value" }, firstName: { type: "value" } };
 
-    // Given a component using `getObjectState` for lazily creating ObjectStates
+    // Given a component using `getFormState` for lazily creating ObjectStates
     function TestComponent() {
       const [apiData, setApiData] = useState<FormValue>({ id: "a:1", firstName: "Brandon" });
-      const { getObjectState } = useFormStates<FormValue, FormValue>({ config, autoSave, getId: (o) => o.id! });
+      const { getFormState } = useFormStates<FormValue, FormValue>({ config, autoSave, getId: (o) => o.id! });
       // Memoize an original for comparing the update against.
-      const originalState = useMemo(() => getObjectState(apiData), []);
-      const state = getObjectState(apiData);
+      const originalState = useMemo(() => getFormState(apiData), []);
+      const state = getFormState(apiData);
 
       return (
         <div>
@@ -78,14 +78,14 @@ describe("useFormStates", () => {
       lastName: { type: "value" },
     };
 
-    // Given a component using `getObjectState` for lazily creating ObjectStates
+    // Given a component using `getFormState` for lazily creating ObjectStates
     function TestComponent() {
       const [apiData, setApiData] = useState<FormValue>({ id: "a:1", firstName: "Tony", lastName: "Stark" });
       const [apiData2, setApiData2] = useState<FormValue>({ id: "a:2", firstName: "Steve", lastName: "Rogers" });
 
-      const { getObjectState } = useFormStates<FormValue, FormValue>({ config, autoSave, getId: (o) => o.id! });
-      const state = getObjectState(apiData);
-      const state2 = getObjectState(apiData2);
+      const { getFormState } = useFormStates<FormValue, FormValue>({ config, autoSave, getId: (o) => o.id! });
+      const state = getFormState(apiData);
+      const state2 = getFormState(apiData2);
 
       async function autoSave(form: ObjectState<FormValue>) {
         autoSaveStub(form.changedValue);
@@ -157,10 +157,10 @@ describe("useFormStates", () => {
 
     function TestComponent() {
       const [config, setConfig] = useState(originalConfig);
-      const { getObjectState } = useFormStates<FormValue, FormValue>({ config, autoSave, getId: (o) => o.id! });
+      const { getFormState } = useFormStates<FormValue, FormValue>({ config, autoSave, getId: (o) => o.id! });
       // Memoize an original for comparing the update against.
-      const originalState = useMemo(() => getObjectState(apiData), []);
-      const state = getObjectState(apiData);
+      const originalState = useMemo(() => getFormState(apiData), []);
+      const state = getFormState(apiData);
 
       return (
         <div>
@@ -186,16 +186,16 @@ describe("useFormStates", () => {
 
     function TestComponent() {
       const config: ObjectConfig<FormValue> = { id: { type: "value" }, firstName: { type: "value" } };
-      const { getObjectState } = useFormStates<FormValue, FormValue>({
+      const { getFormState } = useFormStates<FormValue, FormValue>({
         config,
         addRules,
         getId: (o) => o.id!,
       });
       return (
         <div>
-          {/* And pretend this getObjectState was called in multiple renders. */}
-          <ChildComponent os={getObjectState({ id: "a:1", firstName: "Brandon" })} />
-          <ChildComponent os={getObjectState({ id: "a:1", firstName: "Brandon" })} />
+          {/* And pretend this getFormState was called in multiple renders. */}
+          <ChildComponent os={getFormState({ id: "a:1", firstName: "Brandon" })} />
+          <ChildComponent os={getFormState({ id: "a:1", firstName: "Brandon" })} />
         </div>
       );
     }

--- a/src/useFormStates.ts
+++ b/src/useFormStates.ts
@@ -30,21 +30,21 @@ type UseFormStatesOpts<T, I> = {
   addRules?: (state: ObjectState<T>) => void;
 
   /**
-   * Given an input to `getObjectState`, returns the identity value that we'll cache that value's form state on.
+   * Given an input to `getFormState`, returns the identity value that we'll cache that value's form state on.
    *
    * Does not need to be stable/useMemo'd.
    */
   getId: (v: I) => string;
 
   /**
-   * Maps an input to `getObjectState` to the actual form shape `T`.
+   * Maps an input to `getFormState` to the actual form shape `T`.
    *
    * Does not need to be stable/useMemo'd.
    */
   map?: (input: Exclude<I, null | undefined>) => T;
 };
 
-export function useFormStates<T, I>(opts: UseFormStatesOpts<T, I>): { getObjectState: (input: I) => ObjectState<T> } {
+export function useFormStates<T, I>(opts: UseFormStatesOpts<T, I>): { getFormState: (input: I) => ObjectState<T> } {
   const { config, autoSave, getId, map, addRules } = opts;
   const objectStateCache = useMemo<ObjectStateCache<T, I>>(
     () => ({}),
@@ -79,7 +79,7 @@ export function useFormStates<T, I>(opts: UseFormStatesOpts<T, I>): { getObjectS
     }
   }
 
-  const getObjectState = useCallback(
+  const getFormState = useCallback(
     (input: I) => {
       const existing = objectStateCache[getId(input)];
       let form = existing?.[0];
@@ -108,7 +108,7 @@ export function useFormStates<T, I>(opts: UseFormStatesOpts<T, I>): { getObjectS
     [objectStateCache, config],
   );
 
-  return { getObjectState };
+  return { getFormState };
 }
 
 // If the user's autoSave hook makes some last-minute `.set` calls to sneak


### PR DESCRIPTION
Open to not doing this, but I've thought a few times that `getFormState` would be closer to the `useFormState` (than `getObjectState`) that engineers typically to use to "use form state", so :shrug: , just throwing it out there.