### PR TITLE
feat: Add useFormStates.readOnly, improve object/field interaction.

### DIFF
--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -777,9 +777,52 @@ describe("formState", () => {
   it("maintain field readOnly state when form is readOnly", () => {
     // Given a formState
     const formState = createObjectState<BookInput>({ title: { type: "value", rules: [required], readOnly: true } }, {});
-
     // Then expect form
     expect(formState.title.readOnly).toBeTruthy();
+  });
+
+  it("has an object-level readOnly=true override field-level readOnly=false", () => {
+    // Given a top-level object
+    const a1 = createAuthorInputState({
+      firstName: "a1",
+      lastName: "aL1",
+      books: [{ title: "b1", classification: dd100 }],
+    });
+    // And it is read-only
+    a1.readOnly = true;
+
+    // Then it's fields are read-only
+    const fields = [a1, a1.firstName, a1.books, a1.books.rows[0].title, a1.books.rows[0].classification];
+    fields.forEach((f) => expect(f.readOnly).toBeTruthy());
+
+    // And even if a specific field tries to _not_ be read-only,
+    // i.e. due to a more granular business rule that happens to
+    // be allowed right now
+    a1.firstName.readOnly = false;
+
+    // Then the field-level rule is ignored, and it's still treated as read-only
+    expect(a1.firstName.readOnly).toBeTruthy();
+  });
+
+  it("has an field-level readOnly=true override object-level readOnly=false", () => {
+    // Given a top-level object
+    const a1 = createAuthorInputState({
+      firstName: "a1",
+      lastName: "aL1",
+      books: [{ title: "b1", classification: dd100 }],
+    });
+    // And the top-level form is explicitly set to read-only=false
+    a1.readOnly = false;
+
+    // Then it's fields are not read-only
+    const fields = [a1, a1.firstName, a1.books, a1.books.rows[0].title, a1.books.rows[0].classification];
+    fields.forEach((f) => expect(f.readOnly).toBeFalsy());
+
+    // But when one of the fields opts in to readOnly
+    a1.firstName.readOnly = true;
+
+    // Then the field-level rule is respected
+    expect(a1.firstName.readOnly).toBeTruthy();
   });
 
   it("canSave returns dirty and touches", () => {

--- a/src/formState.ts
+++ b/src/formState.ts
@@ -351,7 +351,7 @@ function newObjectState<T, P = any>(
         this._readOnly ||
         this._considerReadOnly() ||
         (parentState && parentState().readOnly) ||
-        parentListState?.readOnly
+        !!parentListState?.readOnly
       );
     },
 


### PR DESCRIPTION
I haven't been entirely happy about how the interaction in the past
of having `formState.readOnly = ...` set and then also adding in
per-field `formState.firstName.readOnly = ...` settings.

The current version was kind of ~last-write-win-ish, i.e. you could
set the base `formState` into `readOnly` but then override it with
a field-level set.

This wasn't terrible, but it always wasn't very declarative.

This PR changes to the approach that each field-level read-only-ness
is now just a combination of:

    formState.readOnly || fieldState.readOnly

I.e. either form-level or field-level being true will lock the field.

This technically removes the ability, which the previous setup had,
of allowing a form-level readOnly=true but allowing a specific field
to opt-out and go back to readOnly=false.

However, I like the new "form || field" semantics enough that I think
it's fine to give up this capability, which was kind of made up anyway.
If a page really needed to have "some fields opt _out_ of being read
only", it should probably just not be setting the form-level read only
anyway, and just directly control every form field.

I'm not worried about this breaking change because in Blueprint we hardly
ever use this formState-level + field-level readOnly pattern, and instead
just override the readOnly props on the way into our field components.

But really I'm hoping we can do less of that "override the field
component prop" and do more "set the field state whether it is/is not
read only", with this ergonomic improvement in how the two form-level /
field-level read only flags interact.