### PR TITLE
feat: Rename save/reset to commit/revertChanges.

### DIFF
--- a/src/FormStateApp.test.tsx
+++ b/src/FormStateApp.test.tsx
@@ -13,7 +13,7 @@ describe("FormStateApp", () => {
     fireEvent.blur(r.firstName());
     expect(r.firstName_touched()).toHaveTextContent("true");
 
-    click(r.save);
+    click(r.commitChanges);
     expect(r.firstName_dirty()).toHaveTextContent("false");
     expect(r.firstName_touched()).toHaveTextContent("false");
   });
@@ -22,7 +22,7 @@ describe("FormStateApp", () => {
     const r = await render(<FormStateApp />);
     expect(r.firstName_original()).toHaveTextContent("a1");
     click(r.set);
-    click(r.save);
+    click(r.commitChanges);
     expect(r.firstName_original()).toHaveTextContent("a2");
   });
 });

--- a/src/FormStateApp.tsx
+++ b/src/FormStateApp.tsx
@@ -94,11 +94,11 @@ export function FormStateApp() {
                 <button data-testid="touch" onClick={() => (formState.touched = !formState.touched)}>
                   touch
                 </button>
-                <button data-testid="reset" onClick={() => formState.reset()}>
-                  reset
+                <button data-testid="revertChanges" onClick={() => formState.revertChanges()}>
+                  revert
                 </button>
-                <button data-testid="save" onClick={() => formState.save()}>
-                  save
+                <button data-testid="commitChanges" onClick={() => formState.commitChanges()}>
+                  commit
                 </button>
                 <button data-testid="set" onClick={() => formState.set({ firstName: "a2" })}>
                   set

--- a/src/fields/listField.ts
+++ b/src/fields/listField.ts
@@ -232,17 +232,15 @@ export function newListFieldState<T, K extends keyof T, U>(
       maybeAutoSave();
     },
 
-    reset() {
+    revertChanges() {
       if (originalCopy) {
         this.set(originalCopy, { resetting: true });
-        this.rows.forEach((r) => r.reset());
+        this.rows.forEach((r) => r.revertChanges());
       }
     },
 
-    save() {
-      this.rows.forEach((r) => {
-        r.save();
-      });
+    commitChanges() {
+      this.rows.forEach((r) => r.commitChanges());
       originalCopy = [...((parentInstance[key] as any) || [])];
       _tick.value++;
     },

--- a/src/fields/objectField.ts
+++ b/src/fields/objectField.ts
@@ -235,13 +235,13 @@ export function newObjectState<T, P = any>(
     },
 
     // Resets all fields back to their original values
-    reset() {
-      getFields(this).forEach((f) => f.reset());
+    revertChanges() {
+      getFields(this).forEach((f) => f.revertChanges());
     },
 
     // Saves all current values into _originalValue
-    save() {
-      getFields(this).forEach((f) => f.save());
+    commitChanges() {
+      getFields(this).forEach((f) => f.commitChanges());
     },
 
     // Create a result that is only populated with changed keys

--- a/src/fields/valueField.ts
+++ b/src/fields/valueField.ts
@@ -37,9 +37,9 @@ export interface FieldState<T, V> {
   maybeAutoSave(): void;
   set(value: V, opts?: SetOpts): void;
   /** Reverts back to the original value and resets dirty/touched. */
-  reset(): void;
+  revertChanges(): void;
   /** Accepts the current changed value (if any) as the original and resets dirty/touched. */
-  save(): void;
+  commitChanges(): void;
 }
 
 /** Public options for our `set` command. */
@@ -217,14 +217,14 @@ export function newValueFieldState<T, K extends keyof T>(
       }
     },
 
-    reset() {
+    revertChanges() {
       if (!computed) {
         this.set(this.originalValue, { resetting: true });
       }
       this.touched = false;
     },
 
-    save() {
+    commitChanges() {
       if (isPlainObject(this.originalValue)) {
         this.originalValue = toJS(this.value);
       } else {

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -516,7 +516,7 @@ describe("formState", () => {
     a1.set({ firstName: "first" });
     expect(maybeAutoSave).toBeCalledTimes(1);
     // When we reset
-    a1.reset();
+    a1.revertChanges();
     // We don't call blur again
     expect(maybeAutoSave).toBeCalledTimes(1);
   });
@@ -614,7 +614,7 @@ describe("formState", () => {
     a1.books.add({ title: "b3" });
     expect(a1.books.touched).toEqual(true);
     expect(a1.dirty).toBeTruthy();
-    a1.reset();
+    a1.revertChanges();
     expect(a1.firstName.value).toBe("a1");
     expect(a1.firstName.touched).toBeFalsy();
     expect(a1.lastName.value).toBe("aL1");
@@ -651,7 +651,7 @@ describe("formState", () => {
     // And the "readOnly=true" operation has "beat" the reset operation
     a1.readOnly = true;
     // When we reset
-    a1.reset();
+    a1.revertChanges();
     // Then it still works
     expect(a1.firstName.value).toBe("a1");
     expect(a1.firstName.touched).toBeFalsy();
@@ -684,17 +684,17 @@ describe("formState", () => {
 
     // verify ValueFieldState is dirty, then save, then no longer dirty.
     expect(a1.firstName.dirty).toBeTruthy();
-    a1.firstName.save();
+    a1.firstName.commitChanges();
     expect(a1.firstName.dirty).toBeFalsy();
 
     // verify ListFieldState is dirty, then save, then no longer dirty.
     expect(a1.books.dirty).toBeTruthy();
-    a1.books.save();
+    a1.books.commitChanges();
     expect(a1.books.dirty).toBeFalsy();
 
     // Verify the remaining form is still dirty
     expect(a1.dirty).toBeTruthy();
-    a1.save();
+    a1.commitChanges();
     // Verify after save the whole form is no longer dirty.
     expect(a1.dirty).toBeFalsy();
   });
@@ -961,7 +961,7 @@ describe("formState", () => {
     expect(a.books.rows[1].readOnly).toBeFalsy();
     expect(a.books.rows[1].title.readOnly).toBeFalsy();
     // And reset does not blow up
-    a.reset();
+    a.revertChanges();
   });
 
   it("can set nested values when original null", () => {
@@ -1026,7 +1026,7 @@ describe("formState", () => {
     formState.firstName.value = "change";
     expect(formState.fullName.value).toEqual("change last");
 
-    formState.reset();
+    formState.revertChanges();
     expect(formState.firstName.value).toEqual("first");
   });
 
@@ -1043,7 +1043,7 @@ describe("formState", () => {
     expect(formState.firstName.value).toEqual("Bob");
     formState.fullName.set("Fred Smith");
     expect(formState.firstName.value).toEqual("Fred");
-    formState.reset();
+    formState.revertChanges();
     expect(formState.firstName.value).toEqual("first");
   });
 
@@ -1063,7 +1063,7 @@ describe("formState", () => {
     formState.firstName.value = "change";
     expect(formState.fullName.value).toEqual("change last");
 
-    formState.reset();
+    formState.revertChanges();
     expect(formState.firstName.value).toEqual("first");
   });
 
@@ -1501,7 +1501,7 @@ describe("formState", () => {
     // Then the list state is dirty
     expect(a1.books.dirty).toBeTruthy();
     // When saving the form state
-    a1.save();
+    a1.commitChanges();
     // Then the list is no longer dirty
     expect(a1.books.dirty).toBeFalsy();
     // When adding a new book


### PR DESCRIPTION
Two reasons:

1. I'd always found the `fs.save()` to be somewhat unclear about
what it actually did.

2. If we eventually get fancy with handling both "auto save and
create save", having the `fs.save()` method name available would
be nice.