### PR TITLE
feat: Add useAutoSaveStatus.setLoading function.

### DIFF
--- a/src/AutoSaveStatus/useAutoSaveStatus.test.tsx
+++ b/src/AutoSaveStatus/useAutoSaveStatus.test.tsx
@@ -1,6 +1,9 @@
 import { act, renderHook } from "@testing-library/react-hooks";
-import { AutoSaveStatus, AutoSaveStatusProvider } from "./AutoSaveStatusProvider";
+import { useContext } from "react";
+import { AutoSaveStatus, AutoSaveStatusContext, AutoSaveStatusProvider } from "./AutoSaveStatusProvider";
 import { useAutoSaveStatus } from "./useAutoSaveStatus";
+
+const wrapper = AutoSaveStatusProvider;
 
 describe(useAutoSaveStatus, () => {
   /** The internal setTimeout running after tests is spamming the console, so cancel them all here */
@@ -15,69 +18,47 @@ describe(useAutoSaveStatus, () => {
   });
 
   it("renders with a provider", () => {
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
+    const { result } = renderHook(() => useAutoSaveStatus(), { wrapper });
 
     expect(result.current.status).toBe(AutoSaveStatus.IDLE);
   });
 
   it("indicates when something is in-flight", () => {
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
+    const { result } = renderHook(() => useAutoSaveStatus(), { wrapper });
 
-    act(() => result.current.triggerAutoSave());
+    act(() => result.current.setLoading(true));
 
     expect(result.current.status).toBe(AutoSaveStatus.SAVING);
   });
 
   it("indicates when a request has settled", () => {
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
+    const { result } = renderHook(() => useAutoSaveStatus(), { wrapper });
 
-    act(() => result.current.triggerAutoSave());
-    act(() => result.current.resolveAutoSave());
+    act(() => result.current.setLoading(true));
+    act(() => result.current.setLoading(false));
 
     expect(result.current.status).toBe(AutoSaveStatus.DONE);
   });
 
   it("indicates when an error happened", () => {
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
+    const { result } = renderHook(() => useAutoSaveStatus(), { wrapper });
 
-    act(() => result.current.triggerAutoSave());
-    act(() => result.current.resolveAutoSave(new Error("Some error")));
+    act(() => result.current.setLoading(true));
+    act(() => result.current.setLoading(false, "Some error"));
 
     expect(result.current.status).toBe(AutoSaveStatus.ERROR);
     expect(result.current.errors.length).toBe(1);
   });
 
-  it("resets status to Idle when told to", () => {
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
-
-    act(() => result.current.triggerAutoSave());
-    act(() => result.current.resolveAutoSave());
-    act(() => result.current.resetStatus());
-
-    expect(result.current.status).toBe(AutoSaveStatus.IDLE);
-  });
-
   it("status goes through the full lifecycle when passed a reset timeout", async () => {
     // Given a timeout has been passed to `useAutoSave()`
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider resetToIdleTimeout={1_000}>{children}</AutoSaveStatusProvider>,
-    });
+    const { result } = renderHook(() => useAutoSaveStatus(), { wrapper });
     // When we trigger a save
-    act(() => result.current.triggerAutoSave());
+    act(() => result.current.setLoading(true));
     // Then status is Saving
     expect(result.current.status).toBe(AutoSaveStatus.SAVING);
     // And when we trigger a resolution
-    act(() => result.current.resolveAutoSave());
+    act(() => result.current.setLoading(false));
     // Then status is Done
     expect(result.current.status).toBe(AutoSaveStatus.DONE);
     // But when the timer runs out
@@ -89,25 +70,21 @@ describe(useAutoSaveStatus, () => {
   });
 
   it("clears errors on reset status", () => {
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
-    act(() => result.current.triggerAutoSave());
-    act(() => result.current.resolveAutoSave(new Error("some error")));
+    const { result } = renderHook(() => useAutoSaveStatus(), { wrapper });
+    act(() => result.current.setLoading(true));
+    act(() => result.current.setLoading(false, "some error"));
     expect(result.current.errors.length).toBe(1);
-    act(() => result.current.resetStatus());
+    act(() => result.current.setLoading(true));
     expect(result.current.errors.length).toBe(0);
-    expect(result.current.status).toBe(AutoSaveStatus.IDLE);
+    expect(result.current.status).toBe(AutoSaveStatus.SAVING);
   });
 
   it("does not automatically invoke reset timeout if there are errors", () => {
     // Given a timeout has been passed to `useAutoSave()`
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
+    const { result } = renderHook(() => useAutoSaveStatus(), { wrapper });
 
-    act(() => result.current.triggerAutoSave());
-    act(() => result.current.resolveAutoSave(new Error("Some error")));
+    act(() => result.current.setLoading(true));
+    act(() => result.current.setLoading(false, "Some error"));
     act(() => {
       jest.runOnlyPendingTimers();
     });
@@ -116,27 +93,8 @@ describe(useAutoSaveStatus, () => {
     expect(result.current.errors.length).toBe(1);
   });
 
-  it("does allow manual resetting even if there are errors", () => {
-    // Given a timeout has been passed to `useAutoSave()`
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
-
-    act(() => result.current.triggerAutoSave());
-    act(() => result.current.resolveAutoSave(new Error("Some error")));
-    act(() => {
-      jest.runOnlyPendingTimers();
-    });
-    act(() => result.current.resetStatus());
-
-    expect(result.current.status).toBe(AutoSaveStatus.IDLE);
-    expect(result.current.errors.length).toBe(0);
-  });
-
   it("handles multiple in-flight requests", () => {
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
+    const { result } = renderHook(() => useContext(AutoSaveStatusContext), { wrapper });
 
     // When we trigger 2 AutoSaves and only resolve 1
     act(() => result.current.triggerAutoSave());
@@ -154,21 +112,17 @@ describe(useAutoSaveStatus, () => {
   });
 
   it("clears errors when a new save is triggered", () => {
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
+    const { result } = renderHook(() => useContext(AutoSaveStatusContext), { wrapper });
 
     act(() => result.current.triggerAutoSave());
-    act(() => result.current.resolveAutoSave(new Error("some error")));
+    act(() => result.current.resolveAutoSave("some error"));
     act(() => result.current.triggerAutoSave());
 
     expect(result.current.errors.length).toBe(0);
   });
 
   it("handles calling resolve too much", () => {
-    const { result } = renderHook(() => useAutoSaveStatus(), {
-      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
-    });
+    const { result } = renderHook(() => useContext(AutoSaveStatusContext), { wrapper });
 
     // When save hasn't been invoked yet
     act(() => result.current.resolveAutoSave());

--- a/src/AutoSaveStatus/useAutoSaveStatus.ts
+++ b/src/AutoSaveStatus/useAutoSaveStatus.ts
@@ -1,6 +1,56 @@
-import { useContext } from "react";
-import { AutoSaveStatusContext } from "./AutoSaveStatusProvider";
+import { useCallback, useContext, useEffect, useRef } from "react";
+import { AutoSaveStatus, AutoSaveStatusContext } from "./AutoSaveStatusProvider";
 
-export function useAutoSaveStatus() {
-  return useContext(AutoSaveStatusContext);
+export interface AutoSaveStatusHook {
+  status: AutoSaveStatus;
+  errors: string[];
+  /**
+   * Sets the current component's loading state.
+   *
+   * If `error` is passed, it will be added as `errors`; note that we assume `error`
+   * will be passed on the loading `true` -> `false` transition.
+   */
+  setLoading(loading: boolean, error?: string): void;
+}
+
+/**
+ * Provides the current auto-save `status` as well as a `setInFlight` setter
+ * to easily flag the current component's loading state as true/false.
+ *
+ * If your component makes multiple API calls, you can also use two `useAutoSaveStatus`
+ * hooks, i.e.:
+ *
+ * ```
+ * const { setLoading: setLoadingA } = useAutoSaveStatus();
+ * const { setLoading: setLoadingB } = useAutoSaveStatus();
+ * ```
+ *
+ * Also ideally your application's infra will automatically integrate `useAutoSaveStatus`
+ * into all/most wire calls, i.e. by having your own `useMutation` wrapper.
+ */
+export function useAutoSaveStatus(): AutoSaveStatusHook {
+  const { status, errors, triggerAutoSave, resolveAutoSave } = useContext(AutoSaveStatusContext);
+
+  // Keep a ref to our current value so that we can resolveAutoSave on unmount
+  const isLoading = useRef(false);
+
+  // Make a setter that can be called on every render but only trigger/resolve if loading changed
+  const setLoading = useCallback(
+    (loading: boolean, error?: string) => {
+      if (loading !== isLoading.current) {
+        loading ? triggerAutoSave() : resolveAutoSave(error);
+        isLoading.current = loading;
+      }
+    },
+    [triggerAutoSave, resolveAutoSave],
+  );
+
+  // Ensure we resolveAutoSave on unmount
+  useEffect(() => {
+    return () => {
+      isLoading.current && resolveAutoSave();
+    };
+  }, [resolveAutoSave]);
+
+  return { status, errors, setLoading };
 }

--- a/src/useFormStates.ts
+++ b/src/useFormStates.ts
@@ -22,7 +22,7 @@ type UseFormStatesOpts<T, I> = {
   autoSave?: (state: ObjectState<T>) => Promise<void>;
 
   /**
-   * A hook to add custom, cross-field validation rules that can be difficult to setup directly in the config DSL.
+   * A hook to add custom, cross-field validation rules that can be difficult to set up directly in the config DSL.
    *
    * This will be called once-per `ObjectState` instance, and so is effectively a `useEffect` hook with
    * a `[config, objectState]` dependency.
@@ -72,7 +72,7 @@ export function useFormStates<T, I = T>(opts: UseFormStatesOpts<T, I>): UseFormS
   // Use a ref b/c we're memod
   const readOnlyRef = useRef<boolean>(readOnly);
   readOnlyRef.current = readOnly;
-  const autoSaveStatusContext = useAutoSaveStatus();
+  const { setLoading } = useAutoSaveStatus();
 
   const getFormState = useCallback<UseFormStatesHook<T, I>["getFormState"]>(
     (input, opts = {}) => {
@@ -90,7 +90,7 @@ export function useFormStates<T, I = T>(opts: UseFormStatesOpts<T, I>): UseFormS
           let maybeError: undefined | string;
           try {
             isAutoSaving = true;
-            autoSaveStatusContext.triggerAutoSave();
+            setLoading(true);
             // See if we have any reactions that want to run (i.e. added by addRules hooks)
             await new Promise((resolve) => setTimeout(resolve, 0));
             // If a reaction re-queued our form during the ^ wait, remove it
@@ -101,7 +101,7 @@ export function useFormStates<T, I = T>(opts: UseFormStatesOpts<T, I>): UseFormS
             throw e;
           } finally {
             isAutoSaving = false;
-            autoSaveStatusContext.resolveAutoSave(maybeError);
+            setLoading(false, maybeError?.toString());
             if (pending.size > 0) {
               const first = pending.values().next().value!;
               pending.delete(first);


### PR DESCRIPTION
This helps manage some of the "make sure to resolve on unmount" that
we'd seen in this PR:

https://github.com/homebound-team/internal-frontend/pull/2417/files?w=1