### PR TITLE
fix: Fix cache refreshes being mistaken as edits.

### DIFF
--- a/src/fields/valueField.ts
+++ b/src/fields/valueField.ts
@@ -198,7 +198,7 @@ export function newValueFieldState<T, K extends keyof T>(
 
       // If the user has deleted/emptied a value that was originally set, keep it as `null`
       // so that our partial update to the backend correctly unsets it.
-      const keepNull = !isEmpty(this.originalValue) && isEmpty(value);
+      const keepNull = !isEmpty(this.originalValue) && isEmpty(value) && !opts.refreshing;
       // If a list of primitives was originally undefined, coerce `[]` to `undefined`
       const coerceEmptyList = value && value instanceof Array && value.length === 0 && isEmpty(this.originalValue);
       const newValue = keepNull ? null : isEmpty(value) || coerceEmptyList ? undefined : value;
@@ -236,7 +236,9 @@ export function newValueFieldState<T, K extends keyof T>(
 
     get originalValue(): V | null | undefined {
       // A dummy check to for reactivity around our non-proxy value
-      return _originalValueTick.value > -1 ? _originalValue : _originalValue;
+      const value = _originalValueTick.value > -1 ? _originalValue : _originalValue;
+      // Re-create the `keepNull` logic so that `.value` === `.originalValue`
+      return value === null ? (undefined as any) : value;
     },
 
     set originalValue(v: V | null | undefined) {

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -160,6 +160,12 @@ export function useFormState<T, I>(opts: UseFormStateOpts<T, I>): ObjectState<T>
       return;
     }
     setLoading(form, opts);
+    // Note: maybe someday we want to watch the `id` value and notice if it's changing (i.e. 2 -> 3),
+    // and treat this more as a reset than a refresh, b/c the id changing means it's probably
+    // not "the cache refreshed after a mutation save" but "the cache changed b/c of changing
+    // rows in the table that our side panel's form has open/is focused on" (which ideally would
+    // be treated as a full component remount by having an `key` field somewhere in the parent
+    // component, but it's unlikely the user will always remember to do this).
     (form as any).set(initValue(config, init), { refreshing: true });
   }, [form, ...dep]);
 


### PR DESCRIPTION
We had a weird issue in Blueprint that has:

1. User is on task 1, `tradePartnerId = 123`
2. User moves to task 2, which sets `tradePartnerId = undefined`
   * Because there was no `key=` in the sidebar component hierarchy, react treated this "move to the next row" as "just another re-render", so `useFormState` didn't realize this was essentially "a brand new/separate task" and instead treated the incoming `task` fragment as "a new version of the already-being-editted task"
3. When we set values like "TP 123" to `undefined`, we really store them as `null` so the backend knows to do a delete/unset of the field (so `tradePartnerId` was now stored internally as `null`)
4. We had a bug where `.value` would correctly turn `null` back into `undefined` on reads, but `.originalValue` (Which was also `null`) didn't know to do that, so when `.dirty` saw `undefined !== null`, it treated the `tradePartnerId` field as dirty (even though we'd just switched rows)
5. When we move back to task 1, the cache refresh would set `tradePartnerId = 123` again, but the `.set` was ignored b/c the `dirty=true` meant form-state thought the user was mid-edit (i.e. we don't want to mash their WIP edits)

So, the core fix is teaching `originalValue` to "change itself back to `undefined`" if we're storing the `null`-as-a-delete value. This is what `.value` already does, and so teaching `.originalValue` to do the same thing means form-state sees them both as `undefined` and no longer treats the field as dirty.

Which means moving back to task 1 doesn't drop the `tradePartnerId = 123` anymore.

And additional small fix is to disable the `keepNull` logic if `opts.refreshing` is happening, b/c refreshing values only come from the server, so we shouldn't have to remember to `null` out the value on save.

@JonnCharpentier and I also discussed an additional fix of trying to teach form-state to fundamentally recognize the "I'm moving from task 1 to task 2" and realize this is "more" than just a "cache refresh after save", and likely the user just moving to a net-new entity, and so we should not use any of the "be careful not to nuke WIP values".

Maybe we should do that, but it's not strictly necessary to fix any behavior, so we're going to hold off for now.

Also, arguably the most correct fix is for `TaskDetailPane` to use a `key=task.id` somewhere to tell the components to more fully remount/reset their state.

That said, it seems like it would be easy for users to forget this nuance of "set a key around your form state", hence the fixes in this PR to make it still basically work as expected.