### PR TITLE
feat: Simplify FieldState by removing rule object param.

### DIFF
--- a/src/FormStateApp.tsx
+++ b/src/FormStateApp.tsx
@@ -125,7 +125,7 @@ const formConfig: ObjectConfig<AuthorInput> = {
   },
 };
 
-export function TextField(props: { field: FieldState<any, string | null | undefined> }) {
+export function TextField(props: { field: FieldState<string | null | undefined> }) {
   const { field } = props;
   // Somewhat odd: input won't update unless we use <Observer>, even though our
   // parent uses `<Observer>`

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,7 +41,7 @@ export type FragmentFieldConfig = {
 /** Field configuration for primitive values, i.e. strings/numbers/Dates/user-defined types. */
 export type ValueFieldConfig<T, V> = {
   type: "value";
-  rules?: Rule<T, V | null | undefined>[];
+  rules?: Rule<V | null | undefined>[];
   /**
    * If true, marks this field as the id, which will be used for things like "always include in changedValue".
    *
@@ -70,7 +70,7 @@ export type ValueFieldConfig<T, V> = {
 export type ListFieldConfig<T, U> = {
   type: "list";
   /** Rules that can run on the full list of children. */
-  rules?: Rule<T, readonly ObjectState<U>[]>[];
+  rules?: Rule<readonly ObjectState<U>[]>[];
   /** Config for each child's form state, i.e. each book. */
   config: ObjectConfig<U>;
   /**

--- a/src/fields/listField.ts
+++ b/src/fields/listField.ts
@@ -6,7 +6,7 @@ import { required, Rule } from "src/rules";
 import { fail, isNotUndefined } from "src/utils";
 
 /** Form state for list of children, i.e. `U` is a `Book` in a form with a `books: Book[]`. */
-export interface ListFieldState<T, U> extends Omit<FieldState<T, U[]>, "originalValue"> {
+export interface ListFieldState<T, U> extends Omit<FieldState<U[]>, "originalValue"> {
   readonly rows: ReadonlyArray<ObjectState<U>>;
 
   add(value: U, index?: number): void;
@@ -18,7 +18,7 @@ export function newListFieldState<T, K extends keyof T, U>(
   parentInstance: T,
   parentState: () => ObjectState<T>,
   key: K,
-  rules: Rule<T, readonly ObjectState<U>[]>[],
+  rules: Rule<readonly ObjectState<U>[]>[],
   listConfig: ListFieldConfig<T, U>,
   config: ObjectConfig<U>,
   maybeAutoSave: () => void,
@@ -107,7 +107,7 @@ export function newListFieldState<T, K extends keyof T, U>(
           childState = newObjectState<U>(
             config,
             parentState as any,
-            (list as any) as FieldState<any, any>,
+            (list as any) as FieldState<any>,
             child,
             undefined,
             maybeAutoSave,

--- a/src/fields/objectField.ts
+++ b/src/fields/objectField.ts
@@ -34,7 +34,7 @@ export type ObjectState<T, P = any> =
   // Add state.field1, state.field2 for each key in T
   FieldStates<T> &
     // Pull in the touched, blur, dirty, etc
-    FieldState<P, T> & {
+    FieldState<T> & {
       /** Sets the state of fields in `state`. */
       set(state: Partial<T>, opts?: SetOpts): void;
 
@@ -60,10 +60,10 @@ type FieldStates<T> = {
     ? FragmentField<V>
     : T[K] extends Array<infer U> | null | undefined
     ? [U] extends [Builtin]
-      ? FieldState<T, T[K]>
+      ? FieldState<T[K]>
       : ListFieldState<T, U>
     : T[K] extends Builtin | null | undefined
-    ? FieldState<T, T[K]>
+    ? FieldState<T[K]>
     : ObjectState<T[K], T>;
 };
 
@@ -86,7 +86,7 @@ export function createObjectState<T>(
 export function newObjectState<T, P = any>(
   config: ObjectConfig<T>,
   parentState: (() => ObjectState<P>) | undefined,
-  parentListState: FieldState<any, any> | undefined,
+  parentListState: FieldState<any> | undefined,
   instance: T,
   key: keyof T | undefined,
   maybeAutoSave: () => void,
@@ -109,7 +109,7 @@ export function newObjectState<T, P = any>(
       | ObjectFieldConfig<any>
       | ListFieldConfig<T, any>
       | FragmentFieldConfig;
-    let field: FieldState<T, any> | ListFieldState<T, any> | ObjectState<T, P> | FragmentField<any>;
+    let field: FieldState<any> | ListFieldState<T, any> | ObjectState<T, P> | FragmentField<any>;
     if (config.type === "value") {
       field = newValueFieldState(
         instance,

--- a/src/fields/valueField.ts
+++ b/src/fields/valueField.ts
@@ -14,7 +14,7 @@ import { areEqual, fail, isEmpty, isNotUndefined } from "src/utils";
  * Note that `V` will always have `null | undefined` added to it by `FieldStates`, b/c most form fields
  * i.e. text boxes, can always be cleared out/deleted.
  */
-export interface FieldState<T, V> {
+export interface FieldState<V> {
   readonly key: string;
   value: V;
   readonly originalValue: V;
@@ -25,7 +25,7 @@ export interface FieldState<T, V> {
   readonly dirty: boolean;
   readonly valid: boolean;
   readonly isNewEntity: boolean;
-  rules: Rule<T, V>[];
+  rules: Rule<V>[];
   readonly errors: string[];
   /** Returns a subset of V with only the changed values. Currently not observable. */
   readonly changedValue: V;
@@ -56,7 +56,7 @@ export interface InternalSetOpts extends SetOpts {
   refreshing?: boolean;
 }
 
-export interface FieldStateInternal<T, V> extends FieldState<T, V> {
+export interface FieldStateInternal<T, V> extends FieldState<V> {
   set(value: V, opts?: InternalSetOpts): void;
   _isIdKey: boolean;
   _isDeleteKey: boolean;
@@ -68,7 +68,7 @@ export function newValueFieldState<T, K extends keyof T>(
   parentInstance: T,
   parentState: () => ObjectState<T>,
   key: K,
-  rules: Rule<T, T[K] | null | undefined>[],
+  rules: Rule<T[K] | null | undefined>[],
   isIdKey: boolean,
   isDeleteKey: boolean,
   isReadOnlyKey: boolean,
@@ -76,7 +76,7 @@ export function newValueFieldState<T, K extends keyof T>(
   readOnly: boolean,
   strictOrder: boolean,
   maybeAutoSave: () => void,
-): FieldState<T, T[K] | null | undefined> {
+): FieldState<T[K] | null | undefined> {
   type V = T[K];
 
   // keep a copy here for reference equality

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1093,28 +1093,6 @@ describe("formState", () => {
     expect(formState.firstName.value).toEqual("first");
   });
 
-  it("lets rules validate against other fields", () => {
-    const formState = createObjectState<AuthorInput>(
-      {
-        firstName: { type: "value", rules: [] },
-        lastName: {
-          type: "value",
-          rules: [
-            ({ object }) => {
-              if (object.firstName.value === object.lastName.value) {
-                return "Must not match first name";
-              }
-            },
-          ],
-        },
-      },
-      {},
-    );
-    formState.firstName.value = "bob";
-    formState.lastName.value = "bob";
-    expect(formState.lastName.errors).toEqual(["Must not match first name"]);
-  });
-
   it("can return only changed primitive fields", () => {
     // Given an author
     const formState = createObjectState(authorWithBooksConfig, {
@@ -1443,13 +1421,13 @@ describe("formState", () => {
     // @ts-expect-error
     form.id.set(undefined);
     // A BoundField typically has `string | undefined | null` so works on firstName
-    let field1: FieldState<AuthorInput, string | undefined | null>;
+    let field1: FieldState<string | undefined | null>;
     field1 = form.firstName;
     // But not on id
     // @ts-expect-error
     field1 = form.id;
     // And same thing with any as the object type
-    let field2: FieldState<any, string | undefined | null>;
+    let field2: FieldState<string | undefined | null>;
     field2 = form.firstName;
     // @ts-expect-error
     field2 = form.id;
@@ -1468,7 +1446,7 @@ describe("formState", () => {
     // And a bound field that wants a FieldState<any, Address> (even though technically `ObjectState`
     // turns this into a nested `ObjectState` (instead of "just a `FieldState`"), because it can't
     // "see" the `{ type: value }`, until we pass the config as a generic to `ObjectState`.
-    let field: FieldState<any, AuthorAddress | null | undefined>;
+    let field: FieldState<AuthorAddress | null | undefined>;
     // Then we can assign the value
     field = a.address;
     // And treat it as a value object

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,18 +1,7 @@
 import { action } from "mobx";
-import { ObjectState } from "src/fields/objectField";
-
-// https://stackoverflow.com/questions/55541275/typescript-check-for-the-any-type
-type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
 
 /** A validation rule, given the value and name, return the error string if valid, or undefined if valid. */
-export type Rule<T, V> = (opts: {
-  value: V;
-  key: string;
-  originalValue: V;
-  // We need to pass `object` as the ObjectState, so that the rule is registered as an observer.
-  // (The `IfAny` is because the `-?` in `FieldStates breaks the `any` type, see the "weirdness" test.)
-  object: IfAny<T, any, ObjectState<T>>;
-}) => string | undefined;
+export type Rule<V> = (opts: { value: V; key: string; originalValue: V }) => string | undefined;
 
 /** A rule that validates `value` is not `undefined`, `null`, or empty string. */
 // We pre-emptively make this a mobx action so that it's identity doesn't change when proxied

--- a/src/useFormState.test.tsx
+++ b/src/useFormState.test.tsx
@@ -321,14 +321,14 @@ describe("useFormState", () => {
 
   it("useFormState can accept new data with computed fields", async () => {
     // Given a component
-    function TestComponent() {
-      // And it's using a class/mobx proxy as the basis for the data
-      class AuthorRow {
-        constructor(public firstName: string, public lastName: string) {}
-        get fullName() {
-          return this.firstName + " " + this.lastName;
-        }
+    // And it's using a class/mobx proxy as the basis for the data
+    class AuthorRow {
+      constructor(public firstName: string, public lastName: string) {}
+      get fullName() {
+        return this.firstName + " " + this.lastName;
       }
+    }
+    function TestComponent() {
       // And we have two sets of data
       const data1 = { firstName: "f1", lastName: "l1" };
       const data2 = { firstName: "f2", lastName: "l2" };
@@ -760,7 +760,7 @@ const authorWithAddressAndBooksConfig: ObjectConfig<AuthorInput> = {
 };
 
 /** Emulates a user focusing and then blurring a field. */
-function focusAndBlur(state: FieldState<any, any>): void {
+function focusAndBlur(state: FieldState<any>): void {
   state.focus();
   state.blur();
 }

--- a/src/useFormStates.test.tsx
+++ b/src/useFormStates.test.tsx
@@ -50,7 +50,7 @@ describe("useFormStates", () => {
       const [apiData, setApiData] = useState<FormValue>({ id: "a:1", firstName: "Brandon" });
       const { getFormState } = useFormStates<FormValue, FormValue>({ config, autoSave, getId: (o) => o.id! });
       // Memoize an original for comparing the update against.
-      const originalState = useMemo(() => getFormState(apiData), []);
+      const originalState = useMemo(() => getFormState(apiData), [getFormState]);
       const state = getFormState(apiData);
 
       return (
@@ -166,7 +166,7 @@ describe("useFormStates", () => {
       const [config, setConfig] = useState(originalConfig);
       const { getFormState } = useFormStates<FormValue, FormValue>({ config, autoSave, getId: (o) => o.id! });
       // Memoize an original for comparing the update against.
-      const originalState = useMemo(() => getFormState(apiData), []);
+      const originalState = useMemo(() => getFormState(apiData), [getFormState]);
       const state = getFormState(apiData);
 
       return (

--- a/src/useFormStates.test.tsx
+++ b/src/useFormStates.test.tsx
@@ -166,7 +166,8 @@ describe("useFormStates", () => {
       const [config, setConfig] = useState(originalConfig);
       const { getFormState } = useFormStates<FormValue, FormValue>({ config, autoSave, getId: (o) => o.id! });
       // Memoize an original for comparing the update against.
-      const originalState = useMemo(() => getFormState(apiData), [getFormState]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      const originalState = useMemo(() => getFormState(apiData), []);
       const state = getFormState(apiData);
 
       return (


### PR DESCRIPTION
Instead users can use addRules/other ways to do setup cross-field validation rules, instead of from within the rule itself.