### PR TITLE
feat: Change in order of rows in ListState mark it as dirty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@homebound/form-state",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,8 @@ export type ListFieldConfig<T, U> = {
    * default behavior.
    */
   update?: "exhaustive" | "incremental";
+  /** Set to not consider the order of the list when evaluating changed/dirty states. */
+  strictOrder?: false;
 };
 
 export type ObjectFieldConfig<U> = {

--- a/src/fields/objectField.ts
+++ b/src/fields/objectField.ts
@@ -132,6 +132,7 @@ export function newObjectState<T, P = any>(
         config.rules || [],
         config,
         config.config,
+        config.strictOrder ?? true,
         maybeAutoSave,
       );
     } else if (config.type === "object") {

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1531,6 +1531,47 @@ describe("formState", () => {
     expect(a1.books.dirty).toBeTruthy();
   });
 
+  it("can properly evaluate dirty lists when order changes", () => {
+    // Given a list state in a specific order
+    const a = createAuthorInputState({ books: [{ title: "t1" }, { title: "t2" }] });
+    expect(a.books.dirty).toBeFalsy();
+    // When changing that order
+    const book1 = a.books.rows[0].value;
+    a.books.remove(book1);
+    a.books.add(book1);
+    // Then the list state is considered dirty.
+    expect(a.books.dirty).toBeTruthy();
+    // When putting the books back in the original order
+    a.books.remove(book1);
+    a.books.add(book1, 0);
+    // Then the list state is no longer dirty
+    expect(a.books.dirty).toBeFalsy();
+  });
+
+  it("can optionally ignore the order of list state rows when determining dirty state", () => {
+    // Given a list state in a specific order, and the `strictOrder` option set to `false`
+    const a = createObjectState<AuthorInput>(
+      {
+        books: {
+          type: "list",
+          strictOrder: false,
+          config: {
+            title: { type: "value", rules: [required] },
+          },
+        },
+      },
+      { books: [{ title: "t1" }, { title: "t2" }] },
+    );
+
+    expect(a.books.dirty).toBeFalsy();
+    // When changing that order
+    const book1 = a.books.rows[0].value;
+    a.books.remove(book1);
+    a.books.add(book1);
+    // Then the list state is still not considered dirty.
+    expect(a.books.dirty).toBeFalsy();
+  });
+
   describe("fragments", () => {
     type BookWithFragment = BookInput & { data: Fragment<{ foo: string }> };
 


### PR DESCRIPTION
Gives the option to turn off the strict order check for dirty instance.