### PR TITLE
feat: Add Zod-style config api

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 form-state is a headless form state management library, built on top of mobx.
 
-It acts as a buffer between the canonical data (i.e. the server-side data, or your app's GraphQL/Redux/etc. global store) and the user's WIP data that is being actively mutated in form fields (which is "too chatty"/WIP to store in the global store).
+It acts as a buffer between the canonical data (i.e. the server-side data, or your app's GraphQL/Redux/etc. global store) and the user's WIP data that is being actively mutated in form fields (which is "too chatty"/WIP to push back into global stores).
 
 It also keeps track of low-level form UX details like:
 
@@ -21,7 +21,7 @@ It also keeps track of low-level form UX details like:
 - Building a wire payload that has only changed fields
   - `form.changedValue` will return the entity `id` + only changed fields to faciliate doing partial update APIs
   - Supports collections of children, i.e. a `author: { books: [...} }` will include only changed books if necessary
-  - Child collections can be either exhausive (if any child changes, submit them all) or incremental (only include changed children), to match the backend endpoint's semantics
+  - Child collections can be either exhaustive (if any child changes, submit them all) or incremental (only include changed children), to match the backend endpoint's semantics
 
 # Main Features
 
@@ -37,16 +37,17 @@ The core abstraction that `form-state` provides is a `FieldState` interface that
 ```ts
 // Very simplified example
 interface FieldState {
-  value: V
-  errors: string[]
-  valid: boolean
-  touched: boolean
+  // Can be used to read & write the value bound into the form field
+  value: V;
+  errors: string[];
+  valid: boolean;
+  touched: boolean;
 }
 ```
 
 Which combines all the logical aspects of "a single form field" into a single object/prop.
 
-This facilitates the "gold standard" of form libraries, which is "one line per form field", i.e:
+This facilitates the "gold standard" of form DX, which is "one line per form field", i.e:
 
 ```tsx
 function AuthorEditorComponent() {
@@ -124,14 +125,14 @@ type AuthorFragment = { firstName: string; miscOtherData: {} };
 // For your page's form state, add-in the "extra data"
 type AuthorForm = AuthorInput & {
   // The `Fragment` type tells form-state this is not a regular form field
-  data: Fragment<AuthorFragment >
+  data: Fragment<AuthorFragment>;
 };
 
 // Tell the form config the "fragment" is not a real field
 const config: ObjectConfig<AuthorForm> = {
   firstName: { type: "value", rules: [require] },
   data: { type: "fragment" },
-}
+};
 
 // Now in the component...
 const data = useGraphQLQuery();
@@ -146,7 +147,6 @@ const form = useFormState({
   },
 });
 ```
-
 
 # Internal Implementation Notes
 

--- a/src/FormStateApp.tsx
+++ b/src/FormStateApp.tsx
@@ -1,6 +1,6 @@
 import { Observer } from "mobx-react";
-import { AuthorInput } from "src/formStateDomain";
-import { FieldState, ObjectConfig, required, useFormState } from "src/index";
+import { AuthorInput, BookInput } from "src/formStateDomain";
+import { FieldState, f, useFormState } from "src/index";
 
 export function FormStateApp() {
   const formState = useFormState({
@@ -113,17 +113,15 @@ export function FormStateApp() {
 }
 
 // Configure the fields/behavior for AuthorInput's fields
-const formConfig: ObjectConfig<AuthorInput> = {
-  firstName: { type: "value", rules: [required] },
-  lastName: { type: "value", rules: [required], readOnly: true },
-  books: {
-    type: "list",
-    rules: [({ value: list }) => ((list || []).length === 0 ? "Empty" : undefined)],
-    config: {
-      title: { type: "value", rules: [required] },
-    },
-  },
-};
+const formConfig = f.config<AuthorInput>({
+  firstName: f.value().req(),
+  lastName: f.value().readOnly(),
+  books: f
+    .list<BookInput>({
+      title: f.value().req(),
+    })
+    .rule(({ value }) => (value.length === 0 ? "Empty" : undefined)),
+});
 
 export function TextField(props: { field: FieldState<string | null | undefined> }) {
   const { field } = props;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { Fragment, ObjectState } from "src/fields/objectField";
 import { Rule } from "src/rules";
-import { Builtin } from "src/utils";
+import { Builtin, OmitIf } from "src/utils";
 
 /**
  * Config rules for each field in `T` that we're editing in a form.
@@ -20,18 +20,10 @@ export type ObjectConfig<T> = {
     ? FragmentFieldConfig
     : T[P] extends Array<infer U> | null | undefined
     ? U extends Builtin
-      ? ValueFieldConfig<T, T[P]>
-      : ListFieldConfig<T, U>
-    : ValueFieldConfig<T, T[P]> | ObjectFieldConfig<T[P]>;
+      ? ValueFieldConfig<T[P]>
+      : ListFieldConfig<U>
+    : ValueFieldConfig<T[P]> | ObjectFieldConfig<T[P]>;
 };
-
-// Inverse of SubType: https://medium.com/dailyjs/typescript-create-a-condition-based-subset-types-9d902cea5b8c
-type OmitIf<Base, Condition> = Pick<
-  Base,
-  {
-    [Key in keyof Base]: Base[Key] extends Condition ? never : Key;
-  }[keyof Base]
->;
 
 /** Field configuration for an opaque value that we don't actually want to include. */
 export type FragmentFieldConfig = {
@@ -39,7 +31,7 @@ export type FragmentFieldConfig = {
 };
 
 /** Field configuration for primitive values, i.e. strings/numbers/Dates/user-defined types. */
-export type ValueFieldConfig<T, V> = {
+export type ValueFieldConfig<V> = {
   type: "value";
   rules?: Rule<V | null | undefined>[];
   /**
@@ -67,7 +59,7 @@ export type ValueFieldConfig<T, V> = {
 };
 
 /** Field configuration for list values, i.e. `U` is `Book` in a form with `books: Book[]`. */
-export type ListFieldConfig<T, U> = {
+export type ListFieldConfig<U> = {
   type: "list";
   /** Rules that can run on the full list of children. */
   rules?: Rule<readonly ObjectState<U>[]>[];

--- a/src/configBuilders.ts
+++ b/src/configBuilders.ts
@@ -1,0 +1,132 @@
+import { FragmentFieldConfig, ListFieldConfig, ObjectConfig, ValueFieldConfig } from "src/config";
+import { Fragment, ObjectState } from "src/fields/objectField";
+import { Rule, required } from "src/rules";
+import { Builtin, OmitIf } from "src/utils";
+
+/**
+ * Provides a Zod-ish API for building form configs.
+ */
+export const f = {
+  /** Creates the top-level config for a form, like an author or book. */
+  config<T>(fields: ObjectConfigBuilderFields<T>): ObjectConfig<T> {
+    return new ObjectConfigBuilder<T>(fields).build();
+  },
+
+  /** Creates the config DSL for an object, like an author or book. */
+  object<T>(fields: ObjectConfigBuilderFields<T>): ObjectConfigBuilder<T> {
+    return new ObjectConfigBuilder<T>(fields);
+  },
+
+  /** Creates the config DSL for an list of objects, like an author's list of books. */
+  list<U>(fields: ObjectConfigBuilderFields<U>): ListFieldConfigBuilder<U> {
+    return new ListFieldConfigBuilder<U>(fields);
+  },
+
+  /** Creates the config DSL for a primitive value, like a first name or phone number. */
+  value<V>(): ValueFieldConfigBuilder<V> {
+    return new ValueFieldConfigBuilder<V>();
+  },
+
+  /** A shorthand for creating a computed value. */
+  computed<V>(): ValueFieldConfigBuilder<V> {
+    return this.value().computed();
+  },
+};
+
+/**
+ * Defines the fields that should be passed into `f.object({ ... })` for fhe form type `T`.
+ *
+ * This is basically a map of `key` in `T` to `f.value()`, `f.list()`, or `f.object()`
+ * DSL objects that define the runtime structure/fields of the form.
+ */
+export type ObjectConfigBuilderFields<T> = {
+  [P in keyof OmitIf<T, Function>]: T[P] extends Fragment<infer V>
+    ? FragmentFieldConfigBuilder
+    : T[P] extends Array<infer U> | null | undefined
+    ? U extends Builtin
+      ? ValueFieldConfigBuilder<T[P]>
+      : ListFieldConfigBuilder<U>
+    : ValueFieldConfigBuilder<T[P]> | ObjectConfigBuilder<T[P]>;
+};
+
+export interface FragmentFieldConfigBuilder {
+  build(): FragmentFieldConfig;
+}
+
+/** Provides a fluent DSL for building up an object's config. */
+export class ObjectConfigBuilder<T> {
+  private config: ObjectConfig<T>;
+
+  constructor(fields: ObjectConfigBuilderFields<T>) {
+    this.config = {} as any;
+    for (const [key, value] of Object.entries(fields)) {
+      (this.config as any)[key] = (value as any).build();
+    }
+  }
+
+  build(): ObjectConfig<T> {
+    return this.config;
+  }
+}
+
+/** Provides a fluent DSL for building up a value's config. */
+export class ValueFieldConfigBuilder<V> {
+  private config: ValueFieldConfig<V> = { type: "value", rules: [] };
+
+  /** Marks the field as required. */
+  req(): this {
+    this.config.rules = [required];
+    return this;
+  }
+
+  /** Marks the field as read only. */
+  readOnly(): this {
+    this.config.readOnly = true;
+    return this;
+  }
+
+  /** Appends `rules` to the field's validation rules. */
+  rules(rules: Rule<V | null | undefined>[]): this {
+    (this.config.rules ??= []).push(...rules);
+    return this;
+  }
+
+  /** Marks the field as computed. */
+  computed(): this {
+    this.config.computed = true;
+    return this;
+  }
+
+  build(): ValueFieldConfig<V> {
+    return this.config;
+  }
+}
+
+/** Provides a fluent DSL for building up a list's config. */
+export class ListFieldConfigBuilder<U> {
+  private config: ListFieldConfig<U>;
+
+  constructor(fields: ObjectConfigBuilderFields<U>) {
+    const config = {} as any;
+    for (const [key, value] of Object.entries(fields)) {
+      config[key] = (value as any).build();
+    }
+    this.config = { type: "list", rules: [], config };
+  }
+
+  /** Appends `rule` to the field's validation rules. */
+  rule(rule: Rule<readonly ObjectState<U>[]>): this {
+    (this.config.rules ??= []).push(rule);
+    return this;
+  }
+
+  /** Appends `rules` to the field's validation rules. */
+  rules(rules: Rule<readonly ObjectState<U>[]>[]): this {
+    (this.config.rules ??= []).push(...rules);
+    return this;
+  }
+
+  build(): ListFieldConfig<U> {
+    return this.config;
+  }
+}

--- a/src/fields/listField.ts
+++ b/src/fields/listField.ts
@@ -19,7 +19,7 @@ export function newListFieldState<T, K extends keyof T, U>(
   parentState: () => ObjectState<T>,
   key: K,
   rules: Rule<readonly ObjectState<U>[]>[],
-  listConfig: ListFieldConfig<T, U>,
+  listConfig: ListFieldConfig<U>,
   config: ObjectConfig<U>,
   strictOrder: boolean,
   maybeAutoSave: () => void,

--- a/src/fields/objectField.ts
+++ b/src/fields/objectField.ts
@@ -2,7 +2,7 @@ import { computed, makeAutoObservable, observable, reaction } from "mobx";
 import { FragmentFieldConfig, ListFieldConfig, ObjectConfig, ObjectFieldConfig, ValueFieldConfig } from "src/config";
 import { FragmentField, newFragmentField } from "src/fields/fragmentField";
 import { ListFieldState, newListFieldState } from "src/fields/listField";
-import { FieldState, FieldStateInternal, InternalSetOpts, newValueFieldState, SetOpts } from "src/fields/valueField";
+import { FieldState, FieldStateInternal, InternalSetOpts, SetOpts, newValueFieldState } from "src/fields/valueField";
 import { Builtin, fail } from "src/utils";
 
 /**
@@ -106,9 +106,9 @@ export function newObjectState<T, P = any>(
   const fieldStates = Object.entries(config).map(([_key, _config]) => {
     const key = _key as keyof T;
     const config = _config as
-      | ValueFieldConfig<T, any>
+      | ValueFieldConfig<any>
       | ObjectFieldConfig<any>
-      | ListFieldConfig<T, any>
+      | ListFieldConfig<any>
       | FragmentFieldConfig;
     let field: FieldState<any> | ListFieldState<any> | ObjectState<T> | FragmentField<any>;
     if (config.type === "value") {
@@ -120,7 +120,7 @@ export function newObjectState<T, P = any>(
         config.isIdKey ||
           // Default the id key to "id" unless some other field has isIdKey set
           (key === "id" &&
-            !(Object.entries(objectConfig) as any as [string, ValueFieldConfig<any, any>][]).some(
+            !(Object.entries(objectConfig) as any as [string, ValueFieldConfig<any>][]).some(
               ([other, c]) => other !== key && c.isIdKey,
             )),
         config.isDeleteKey || false,

--- a/src/fields/valueField.ts
+++ b/src/fields/valueField.ts
@@ -16,7 +16,9 @@ import { areEqual, fail, isEmpty, isNotUndefined } from "src/utils";
  * i.e. text boxes, can always be cleared out/deleted.
  */
 export interface FieldState<V> {
+  /** The key in the parent object, i.e. `firstName` in `author: { firstName: string }`. */
   readonly key: string;
+  /** The current value of the field. */
   value: V;
   readonly originalValue: V;
   touched: boolean;

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1,62 +1,10 @@
-import { autorun, isObservable, makeAutoObservable, observable, ObservableMap, reaction, runInAction } from "mobx";
+import { autorun, isObservable, makeAutoObservable, observable, reaction } from "mobx";
 import { ObjectConfig } from "src/config";
-import { createObjectState, Fragment, fragment, ObjectState } from "src/fields/objectField";
+import { f } from "src/configBuilders";
+import { Fragment, ObjectState, createObjectState, fragment } from "src/fields/objectField";
 import { FieldState } from "src/fields/valueField";
 import { AuthorAddress, AuthorInput, BookInput, Color, DateOnly, dd100, dd200, jan1, jan2 } from "src/formStateDomain";
 import { required } from "src/rules";
-
-describe("mobx behavior", () => {
-  it("mobx batches if in actions", () => {
-    const a = observable({ name: "a1" });
-    const b = observable({ name: "b1" });
-    const map = new ObservableMap<string, { name: string }>();
-    map.set("a", a);
-    map.set("b", b);
-
-    let runs = 0;
-    autorun(() => {
-      noop([...map.values()].filter((v) => v.name.includes("1")));
-      runs++;
-    });
-
-    expect(runs).toBe(1);
-    // When we change both a and b
-    runInAction(() => {
-      a.name = "a11";
-      b.name = "b2";
-    });
-    // Then the reaction waited and only ran once
-    expect(runs).toBe(2);
-  });
-
-  it("mobx can watch undefined keys", () => {
-    const a = new ObservableObject();
-    const b = new ObservableObject();
-    const map = new ObservableMap<string, ObservableObject>();
-    map.set("a", a);
-    map.set("b", b);
-
-    let runs = 0;
-    autorun(() => {
-      noop([...map.values()].map((a) => a.age));
-      runs++;
-    });
-
-    expect(runs).toBe(1);
-    b.age = 1;
-    expect(runs).toBe(2);
-  });
-
-  it("mobx lists maintain observable identity", () => {
-    // given a parent observable
-    const a = observable({ list: [] as {}[] });
-    // if we observable-ize a value being pushing it on the list
-    const c1 = observable({});
-    a.list.push(c1);
-    // then we get identify equality on the list lookups
-    expect(a.list[0] === c1).toEqual(true);
-  });
-});
 
 describe("formState", () => {
   it("can create a simple object", () => {
@@ -1112,6 +1060,16 @@ describe("formState", () => {
     expect(config).toBeDefined();
   });
 
+  it("supports observable objects with helper methods in the config DSL", () => {
+    const config = f.config({
+      firstName: f.value(),
+      lastName: f.value(),
+      fullName: f.computed(),
+    });
+    // Throw away assertion, test is making sure ^ line compiles
+    expect(config).toBeDefined();
+  });
+
   it("can reset observable objects with computeds", () => {
     const formState = createObjectState(
       {
@@ -1745,7 +1703,7 @@ describe("formState", () => {
   });
 });
 
-class ObservableObject {
+export class ObservableObject {
   firstName: string | undefined = "first";
   lastName: string | undefined = "last";
   age?: number | undefined = undefined;
@@ -1769,19 +1727,16 @@ class ObservableObject {
   }
 }
 
-const authorWithBooksConfig: ObjectConfig<AuthorInput> = {
-  id: { type: "value" },
-  firstName: { type: "value" },
-  lastName: { type: "value" },
-  books: {
-    type: "list",
-    config: {
-      id: { type: "value" },
-      title: { type: "value", rules: [required] },
-      classification: { type: "value" },
-    },
-  },
-};
+const authorWithBooksConfig = f.config<AuthorInput>({
+  id: f.value(),
+  firstName: f.value(),
+  lastName: f.value(),
+  books: f.list({
+    id: f.value(),
+    title: f.value().req(),
+    classification: f.value(),
+  }),
+});
 
 function createAuthorInputState(input: AuthorInput, maybeAutoSave?: () => void) {
   return createObjectState<AuthorInput>(authorWithBooksConfig, input, { maybeAutoSave });
@@ -1800,27 +1755,43 @@ const authorWithAddressConfig: ObjectConfig<AuthorInput> = {
   },
 };
 
-const authorWithAddressAndBooksConfig: ObjectConfig<AuthorInput> = {
-  id: { type: "value" },
-  firstName: { type: "value" },
-  lastName: { type: "value" },
-  address: {
-    type: "object",
-    config: {
-      id: { type: "value" },
-      street: { type: "value", rules: [required] },
-      city: { type: "value" },
-    },
-  },
-  books: {
-    type: "list",
-    config: {
-      id: { type: "value" },
-      title: { type: "value", rules: [required] },
-      classification: { type: "value" },
-    },
-  },
-};
+const authorWithAddressAndBooksConfig = f.config<AuthorInput>({
+  id: f.value(),
+  firstName: f.value(),
+  lastName: f.value(),
+  address: f.object({
+    id: f.value(),
+    street: f.value().rules([required]),
+    city: f.value(),
+  }),
+  books: f.list({
+    id: f.value(),
+    title: f.value(),
+    classification: f.value(),
+  }),
+});
+
+// const authorWithAddressAndBooksConfig: ObjectConfig<AuthorInput> = {
+//   id: { type: "value" },
+//   firstName: { type: "value" },
+//   lastName: { type: "value" },
+//   address: {
+//     type: "object",
+//     config: {
+//       id: { type: "value" },
+//       street: { type: "value", rules: [required] },
+//       city: { type: "value" },
+//     },
+//   },
+//   books: {
+//     type: "list",
+//     config: {
+//       id: { type: "value" },
+//       title: { type: "value", rules: [required] },
+//       classification: { type: "value" },
+//     },
+//   },
+// };
 
 function createAuthorWithAddressInputState(input: AuthorInput) {
   return createObjectState<AuthorInput>(authorWithAddressConfig, input);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { ObjectConfig } from "src/config";
+export { f } from "src/configBuilders";
 export { ListFieldState } from "src/fields/listField";
 export { ObjectState, createObjectState } from "src/fields/objectField";
 export { FieldState, ValueAdapter } from "src/fields/valueField";

--- a/src/mobx-behavior.test.ts
+++ b/src/mobx-behavior.test.ts
@@ -1,0 +1,57 @@
+import { autorun, observable, ObservableMap, runInAction } from "mobx";
+import { ObservableObject } from "src/formState.test";
+
+describe("mobx behavior", () => {
+  it("mobx batches if in actions", () => {
+    const a = observable({ name: "a1" });
+    const b = observable({ name: "b1" });
+    const map = new ObservableMap<string, { name: string }>();
+    map.set("a", a);
+    map.set("b", b);
+
+    let runs = 0;
+    autorun(() => {
+      noop([...map.values()].filter((v) => v.name.includes("1")));
+      runs++;
+    });
+
+    expect(runs).toBe(1);
+    // When we change both a and b
+    runInAction(() => {
+      a.name = "a11";
+      b.name = "b2";
+    });
+    // Then the reaction waited and only ran once
+    expect(runs).toBe(2);
+  });
+
+  it("mobx can watch undefined keys", () => {
+    const a = new ObservableObject();
+    const b = new ObservableObject();
+    const map = new ObservableMap<string, ObservableObject>();
+    map.set("a", a);
+    map.set("b", b);
+
+    let runs = 0;
+    autorun(() => {
+      noop([...map.values()].map((a) => a.age));
+      runs++;
+    });
+
+    expect(runs).toBe(1);
+    b.age = 1;
+    expect(runs).toBe(2);
+  });
+
+  it("mobx lists maintain observable identity", () => {
+    // given a parent observable
+    const a = observable({ list: [] as {}[] });
+    // if we observable-ize a value being pushing it on the list
+    const c1 = observable({});
+    a.list.push(c1);
+    // then we get identify equality on the list lookups
+    expect(a.list[0] === c1).toEqual(true);
+  });
+});
+
+function noop(t: unknown): void {}

--- a/src/stackoverlfow.ts
+++ b/src/stackoverlfow.ts
@@ -1,0 +1,30 @@
+// Create a Zod-style fluent DSL for building config
+const c = {
+  value<V>(): ValueConfig<V> {
+    return null!;
+  },
+};
+
+type Config<T> = { [P in keyof T]: ValueConfig<T[P]> };
+
+function config<T>(object: Config<T>): void {}
+
+// Allow fluent methods
+interface ValueConfig<V> {
+  req(): ValueConfig<V>;
+  readOnly(): ValueConfig<V>;
+  validate(fn: (value: V) => boolean): ValueConfig<V>;
+}
+
+// An pojo
+type Author = { name: string; address: string; city: string };
+
+// Try and configure the author
+config<Author>({
+  // correctly inferred as c.value<string> --> ValueConfig<string>
+  name: c.value(),
+  // inferred only as c.value<unknown> --> ValueConfig<unknown>
+  address: c.value<string>().req(),
+  // compile error, v is implicitly typed as any
+  city: c.value<string>().validate((v) => v.length > 0),
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,6 +19,14 @@ export type DeepRequired<T> = T extends Primitive
         : DeepRequired<T[P]>;
     };
 
+// Inverse of SubType: https://medium.com/dailyjs/typescript-create-a-condition-based-subset-types-9d902cea5b8c
+export type OmitIf<Base, Condition> = Pick<
+  Base,
+  {
+    [Key in keyof Base]: Base[Key] extends Condition ? never : Key;
+  }[keyof Base]
+>;
+
 export function fail(message?: string): never {
   throw new Error(message || "Failed");
 }
@@ -67,10 +75,7 @@ export function pickFields<T, I>(
   }
   return Object.fromEntries(
     Object.entries(formConfig).map(([key, _keyConfig]) => {
-      const keyConfig = _keyConfig as any as
-        | ObjectFieldConfig<any>
-        | ListFieldConfig<any, any>
-        | ValueFieldConfig<any, any>;
+      const keyConfig = _keyConfig as any as ObjectFieldConfig<any> | ListFieldConfig<any> | ValueFieldConfig<any>;
       const value = (instance as any)[key];
       if (keyConfig.type === "object") {
         if (value) {


### PR DESCRIPTION
Instead of:

```ts
const formConfig: ObjectConfig<AuthorInput> = {
  firstName: { type: "value", rules: [required] },
  lastName: { type: "value", rules: [required], readOnly: true },
  books: {
    type: "list",
    config: {
      title: { type: "value", rules: [required] },
    },
  },
};
```

We can do:

```ts
const formConfig = f.config<AuthorInput>({
  firstName: f.value().req(),
  lastName: f.value().readOnly(),
  books: f.list({
    title: f.value().req(),
  }),
});
```
