### PR TITLE
fix: Fix computeds always being dirty.

### DIFF
--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1105,16 +1105,18 @@ describe("formState", () => {
       {
         firstName: { type: "value" },
         lastName: { type: "value" },
-        fullName: { type: "value", computed: true },
+        fullName: { type: "value" },
       },
       new ObservableObject(),
     );
 
     expect(formState.firstName.value).toEqual("first");
     expect(formState.fullName.value).toEqual("first last");
+    expect(formState.fullName.dirty).toEqual(false);
 
     formState.firstName.value = "change";
     expect(formState.fullName.value).toEqual("change last");
+    expect(formState.fullName.dirty).toEqual(true);
 
     formState.revertChanges();
     expect(formState.firstName.value).toEqual("first");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,9 +148,17 @@ export function deepClone<T>(obj: T, map = new WeakMap()): T {
     if (map.has(obj)) return map.get(obj);
     const result = Array.isArray(obj) ? [] : {};
     map.set(obj, result);
-    Object.assign(result, ...Object.keys(obj).map((key) => ({ [key]: deepClone((obj as any)[key], map) })));
+    Object.assign(result, ...getAllPropertyNames(obj).map((key) => ({ [key]: deepClone((obj as any)[key], map) })));
     return result as T;
   } else {
     return obj;
   }
+}
+
+/** Returns all property names, including mobx computeds (non-enumerable) & inherited. */
+function getAllPropertyNames(obj: unknown): string[] {
+  const proto = Object.getPrototypeOf(obj);
+  // Don't crawl up into Object.prototype, or into arrays/observable arrays
+  const inherited = proto && proto !== Object.prototype && !Array.isArray(obj) ? getAllPropertyNames(proto) : [];
+  return [...new Set(Object.getOwnPropertyNames(obj).concat(inherited))];
 }


### PR DESCRIPTION
Got missed in the last refactoring of `originalValue` handling (which is used for dirty checking) that mobx computeds don't show up in `Object.keys`. :shrug: 
