### PR TITLE
fix: Trigger auto-saves when observables are mutated directly.

### DIFF
--- a/src/fields/listField.ts
+++ b/src/fields/listField.ts
@@ -109,6 +109,10 @@ export function newListFieldState<T, K extends keyof T, U>(
       return this.rows.some((r) => r.dirty) || this.hasChanged();
     },
 
+    get focused(): boolean {
+      return this.rows.some((r) => r.focused);
+    },
+
     get required(): boolean {
       return this.rules.some((rule) => rule === required);
     },

--- a/src/fields/objectField.ts
+++ b/src/fields/objectField.ts
@@ -201,6 +201,10 @@ export function newObjectState<T, P = any>(
       return !!readOnlyField?.value;
     },
 
+    get focused(): boolean {
+      return getFields(this).some((f) => f.focused);
+    },
+
     get touched(): boolean {
       return getFields(this).some((f) => f.touched);
     },


### PR DESCRIPTION
With a check to make sure it's not us ourselves doing the mutation.