### PR TITLE
feat: Teach changedValue to handle references

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,8 @@ export type ListFieldConfig<U> = {
 
 export type ObjectFieldConfig<U> = {
   type: "object";
+  /** Marks an object as a reference, which means we'll only include it's `id` in `changedValue` output. */
+  reference?: boolean;
   /** Config for the child's form state, i.e. each book. */
   config: ObjectConfig<U>;
 };

--- a/src/configBuilders.test.ts
+++ b/src/configBuilders.test.ts
@@ -1,0 +1,67 @@
+import { f } from "src/configBuilders";
+import { ObservableObject } from "src/formState.test";
+
+describe("config", () => {
+  it("supports observable objects with helper methods in the config DSL", () => {
+    const config = f.config<ObservableObject>({
+      firstName: f.value(),
+      lastName: f.value(),
+      fullName: f.computed(),
+    });
+    // Throw away assertion, test is making sure ^ line compiles
+    expect(config).toBeDefined();
+  });
+
+  it("supports nested objects", () => {
+    const config = f.config({
+      id: f.value(),
+      address: f.object({ id: f.value() }),
+    });
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "address": {
+          "config": {
+            "id": {
+              "rules": [],
+              "type": "value",
+            },
+          },
+          "type": "object",
+        },
+        "id": {
+          "rules": [],
+          "type": "value",
+        },
+      }
+    `);
+  });
+
+  it("supports Reference alias", () => {
+    const config = f.config({
+      id: f.value(),
+      address: f.reference({ name: f.value() } as any),
+    });
+    expect(config).toMatchInlineSnapshot(`
+      {
+        "address": {
+          "config": {
+            "id": {
+              "rules": [],
+              "type": "value",
+            },
+            "name": {
+              "rules": [],
+              "type": "value",
+            },
+          },
+          "reference": true,
+          "type": "object",
+        },
+        "id": {
+          "rules": [],
+          "type": "value",
+        },
+      }
+    `);
+  });
+});

--- a/src/fields/listField.ts
+++ b/src/fields/listField.ts
@@ -1,6 +1,6 @@
 import { computed, makeAutoObservable, observable, reaction } from "mobx";
-import { ListFieldConfig, ObjectConfig } from "src/config";
-import { ObjectState, ObjectStateInternal, createObjectState, newObjectState } from "src/fields/objectField";
+import { ListFieldConfig, ObjectFieldConfig } from "src/config";
+import { ObjectState, ObjectStateInternal, newObjectState } from "src/fields/objectField";
 import { FieldState, InternalSetOpts } from "src/fields/valueField";
 import { Rule, required } from "src/rules";
 import { fail, isNotUndefined } from "src/utils";
@@ -21,7 +21,7 @@ export function newListFieldState<T, K extends keyof T, U>(
   key: K,
   rules: Rule<readonly ObjectState<U>[]>[],
   listConfig: ListFieldConfig<U>,
-  config: ObjectConfig<U>,
+  config: ObjectFieldConfig<U>,
   strictOrder: boolean,
   maybeAutoSave: () => void,
 ): ListFieldState<U> {
@@ -228,7 +228,8 @@ export function newListFieldState<T, K extends keyof T, U>(
 
     add(value: U, spliceIndex?: number): void {
       // This is called by the user, so value should be a non-proxy value we should keep
-      const childState = createObjectState(config, value, { maybeAutoSave }) as ObjectStateInternal<U>;
+      const childState = getOrCreateChildState(value) as ObjectStateInternal<U>;
+      // const childState = createObjectState(config, value, { maybeAutoSave }) as ObjectStateInternal<U>;
       rowMap.set(value, childState);
       this.ensureSet();
       this.value.splice(typeof spliceIndex === "number" ? spliceIndex : this.value.length, 0, childState.value);

--- a/src/fields/listField.ts
+++ b/src/fields/listField.ts
@@ -63,6 +63,7 @@ export function newListFieldState<T, K extends keyof T, U>(
       childState = newObjectState<U>(
         config,
         parentState as any,
+        undefined,
         list as any as FieldState<any>,
         child,
         undefined,

--- a/src/fields/valueField.ts
+++ b/src/fields/valueField.ts
@@ -110,6 +110,7 @@ export function newValueFieldState<T, K extends keyof T>(
     /** Current readOnly value. */
     _readOnly: readOnly || false,
     _loading: false,
+    _kind: "value",
     // Expose so computed can be skipped in changedValue
     _computed: computed,
     _focused: false,

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -1095,26 +1095,6 @@ describe("formState", () => {
     expect(lastLength).toEqual(2);
   });
 
-  it("supports observable objects with helper methods", () => {
-    const config: ObjectConfig<ObservableObject> = {
-      firstName: { type: "value" },
-      lastName: { type: "value" },
-      fullName: { type: "value", computed: true },
-    };
-    // Throw away assertion, test is making sure ^ line compiles
-    expect(config).toBeDefined();
-  });
-
-  it("supports observable objects with helper methods in the config DSL", () => {
-    const config = f.config({
-      firstName: f.value(),
-      lastName: f.value(),
-      fullName: f.computed(),
-    });
-    // Throw away assertion, test is making sure ^ line compiles
-    expect(config).toBeDefined();
-  });
-
   it("can reset observable objects with computeds", () => {
     const formState = createObjectState(
       {
@@ -1258,36 +1238,86 @@ describe("formState", () => {
       firstName: "f",
       address: { id: "add:1" },
     });
-    // Then changedValue includes the refernece to the FK
+    // Then changedValue includes the reference to the FK
     expect(formState.changedValue).toEqual({
       firstName: "f",
       address: { id: "add:1" },
     });
   });
 
+  it("changedValue includes new entity nested fields with multiple keys", () => {
+    // Given a new author with an address FK
+    const formState = createObjectState(authorWithAddressFkConfig, { firstName: "f" });
+    formState.address.set({ id: "add:1", street: "Main St" });
+    // Then changedValue includes the reference to the FK
+    expect(formState.changedValue).toEqual({
+      firstName: "f",
+      address: { id: "add:1", street: "Main St" },
+    });
+  });
+
   it("changedValue includes deleted nested fields", () => {
     // Given a new author with an address FK
-    const formState = createObjectState(authorWithAddressFkConfig, {
-      id: "a:1",
-      firstName: "f",
-      address: { id: "add:1" },
-    });
+    const formState = createObjectState(
+      f.config<AuthorInput>({
+        id: f.value(),
+        firstName: f.value(),
+        // And address is a reference
+        address: f.reference(),
+      }),
+      { id: "a:1", firstName: "f", address: { id: "add:1" } },
+    );
     // When the address is unset
     formState.address.set(undefined);
     // Then the field is dirty and will be removed in changedValue
     expect(formState.address.dirty).toBe(true);
+    expect(formState.dirty).toBe(true);
     expect(formState.changedValue).toEqual({
       id: "a:1",
-      // maybe we want `address: { id: null }`? Maybe if there is only a single id key...
-      address: null,
+      address: { id: null },
     });
+    // So that we can do a binding like
+    const addressId = formState.changedValue.address?.id;
+    expect(addressId).toBeNull();
     // And when we're restored to the same value
     formState.address.set({ id: "add:1" });
-    // Then we're back
+    // Then it's back to not being dirty
     expect(formState.address.dirty).toBe(false);
+    expect(formState.dirty).toBe(false);
     // And when we're changed to a different address
     formState.address.set({ id: "add:2" });
     // Then we're dirty again
+    expect(formState.changedValue).toEqual({
+      id: "a:1",
+      address: { id: "add:2" },
+    });
+  });
+
+  it("changedValue includes deleted nested fields with a name", () => {
+    // Given a new author with an address FK
+    const formState = createObjectState(
+      f.config<AuthorInput>({
+        id: f.value(),
+        firstName: f.value(),
+        address: f.reference<AuthorAddress>({ street: f.value() }),
+      }),
+      { id: "a:1", firstName: "f", address: { id: "add:1", street: "Main St" } },
+    );
+    // Initially both id and street can be bound to the UI
+    expect(formState.address.id.value).toBe("add:1");
+    expect(formState.address.street.value).toBe("Main St");
+    // When the address is unset
+    formState.address.set(undefined);
+    // Then the field is dirty and will be removed in changedValue
+    expect(formState.address.dirty).toBe(true);
+    // And our changedValue only includes the id
+    expect(formState.changedValue).toEqual({
+      id: "a:1",
+      address: { id: null },
+    });
+    // And when we're changed to a new address
+    formState.address.set({ id: "add:2", street: "Side St" });
+    // Then we see oly the id come back in changedValue
     expect(formState.changedValue).toEqual({
       id: "a:1",
       address: { id: "add:2" },

--- a/src/formStateDomain.ts
+++ b/src/formStateDomain.ts
@@ -25,6 +25,7 @@ export interface AuthorInput {
 }
 
 export interface AuthorAddress {
+  id?: string | null;
   street?: string | null;
   city?: string | null;
 }


### PR DESCRIPTION
I.e. something like:

```ts
const authorForm = f.config({
  id: f.value(),
  publisher: f.reference(),
});

// if author.publisher had been { id: 1, name: ... }
authorForm.publisher.set(undefined);
const publisherId = author.changedValue.publisher?.id;

// this will be null is removed, for putting into a mutation
await saveAuthor({ ..., publisherId });
```

The idea is to help avoid tracking both "a id+name tuple for lazy SelectFields" and "a regular id field for changedValue to put on the wire" like I'm doing in the S&S/CE code atm:

```
  updateProposedBidItem(bidItem: DisplayNamedFragment | undefined) {
    this.proposedBidItem = bidItem;
    this.proposedBidItemId = bidItem?.id ?? null;
  }
```

Solely b/c (without this PR) it's easier to get `proposedBidItemId` into the mutation if it's a standalone key, instead of getting it from the nested `propsoedBidItem` tuple.