### PR TITLE
feat: Add init.onlyOnce.

### DIFF
--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -11,6 +11,7 @@ export type InputAndMap<T, I> = {
   input: I;
   map?: (input: Exclude<I, null | undefined>) => T;
   ifUndefined?: T;
+  onlyOnce?: boolean;
 };
 
 export type QueryAndMap<T, I> = {
@@ -98,7 +99,13 @@ export function useFormState<T, I>(opts: UseFormStateOpts<T, I>): ObjectState<T>
   const [firstInitValue] = useState(() => initValue(config, init));
   const isWrappingMobxProxy = !isPlainObject(firstInitValue);
   // If they're using init.input, useMemo on it (and it might be an array), otherwise allow the identity of init be unstable
-  const dep = isInput(init) ? makeArray(init.input) : isQuery(init) ? [init.query.data, init.query.loading] : [];
+  const dep = isInput(init)
+    ? init.onlyOnce
+      ? []
+      : makeArray(init.input)
+    : isQuery(init)
+      ? [init.query.data, init.query.loading]
+      : [];
 
   const form = useMemo(
     () => {


### PR DESCRIPTION
A previous refactoring removed the ability to do `init: pojo` in
the API, and instead consolidated usage on `init: { input: pojo }`.

This was good, but a surprising artifact of `init: pojo` was that it did not re-init as the identity of pojo changes (vs. the `init.input = pojo` whcih *does* re-init as the identity changes).

This dictomoy between "one re-inits and one does not" was fairly aribtrary and was a big reason behind removing the "two ways of doing things".

That said, in rolling out the change to internal-frontend, a number of callers were enjoying the implicit useMemo-ification of their `init: pojo`, and so this PR adds an `init.onlyOnce` flag that basically restores the "don't watch the init.input identity" behavior.