### PR TITLE
feat: Avoid warnings when using useFormStates.

### DIFF
--- a/src/useFormStates.ts
+++ b/src/useFormStates.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { ObjectConfig } from "src/config";
 import { ObjectState, ObjectStateInternal, createObjectState } from "src/fields/objectField";
 import { initValue } from "src/utils";
@@ -142,15 +142,17 @@ export function useFormStates<T, I = T>(opts: UseFormStatesOpts<T, I>): UseFormS
         objectStateCache[getId(input)] = [form, input];
       }
 
-      // If the source of truth changed, then update the existing state and return it.
-      if (existing && existing[1] !== input) {
-        (form as any as ObjectStateInternal<any>).set(initValue(config, { map, input }), {
-          refreshing: true,
-        });
-        existing[1] = input;
-      }
-
-      form.readOnly = readOnlyRef.current || !!opts.readOnly;
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useEffect(() => {
+        // If the source of truth changed, then update the existing state and return it.
+        if (existing && existing[1] !== input) {
+          (form as any as ObjectStateInternal<any>).set(initValue(config, { map, input }), {
+            refreshing: true,
+          });
+          existing[1] = input;
+        }
+        form.readOnly = readOnlyRef.current || !!opts.readOnly;
+      }, [form, input]);
 
       return form;
     },


### PR DESCRIPTION
Currently when tables call `getFormState(fragment)`, from within their render method (mobx observer), we immediately diff the fragment against the prior fragment, and if it's different, push the update into the formState proxy.

This "update a proxy in a render method" will tick/dirty any other components/observers that are also watching this mobx proxy.

The regular useFormState avoids this by writing to the proxy via a useEffect, which moves the dirty-via-setState out of render methods.

This PR is a spike/proof-of-concept to apply the same useEffect approach to useFormStates, by turning getFormState effectively into a hook itself.