### PR TITLE
fix: Fix merging grand children.

### DIFF
--- a/src/fields/listField.ts
+++ b/src/fields/listField.ts
@@ -117,6 +117,12 @@ export function newListFieldState<T, K extends keyof T, U>(
       return this.rows.some((r) => r.dirty) || this.hasChanged();
     },
 
+    // Having a new entity is slightly different than being dirty, b/c merely having a placeholder-but-not-changed-yet
+    // `isNewEntity` child should not fire autosave (which would happen if we're dirty).
+    get hasNewEntity(): boolean {
+      return this.rows.some((r) => r.isNewEntity);
+    },
+
     get focused(): boolean {
       return this.rows.some((r) => r.focused);
     },
@@ -224,7 +230,7 @@ export function newListFieldState<T, K extends keyof T, U>(
       // passing us cloned rows from the parentCopy, but `getOrCreateChildState` will
       // use the `copyMap` to recover the non-cloned rows, to avoid promoting the clone
       // into a real row.
-      if (this.dirty && opts.refreshing) {
+      if ((this.dirty || this.hasNewEntity) && opts.refreshing) {
         // When refreshing a dirty list, we need to preserve WIP values
 
         // Start with current list, then merge in incoming changes
@@ -240,19 +246,23 @@ export function newListFieldState<T, K extends keyof T, U>(
 
         // Index by idKey or a hash of the object, so we don't have to n^2 merging
         const idKey = this.rows.length > 0 && (this.rows[0] as any as ObjectStateInternal).idKey;
-        const hashItem = (item: any) => (idKey && item[idKey]) || hash(item);
-        const hashWithoutId = (item: any) =>
-          hash(Object.fromEntries(Object.entries(item as object).filter(([key]) => key !== idKey)));
-        const currentById = groupBy(currentItems, hashItem);
-        const incomingById = groupBy(incomingItems, hashItem);
+        // Look at our child config, i.e. `bookConfig` and find the non-id / non-list keys
+        const contentKeys = Object.entries(config.config)
+          .filter(([key, cfg]: any) => key !== idKey && cfg.type === "value")
+          .map(([key]) => key);
+        const hashByContent = (item: any) =>
+          hash(Object.fromEntries(Object.entries(item as object).filter(([key]) => contentKeys.includes(key))));
+        const hashById = (item: any) => (idKey && item[idKey]) || hashByContent(item);
+        const currentById = groupBy(currentItems, hashById);
+        const incomingById = groupBy(incomingItems, hashById);
         // If our local instance doesn't assign in id, when we get results back from the server, strip
         // their id and then see if we're the same based on data. Note that this is a hueristic, and will
         // fail if the client-side has made additional changes to the child after submitting it to the server,
         // or if the server acks back more/different data than the client sent.
         //
         // Only do this if one of our client-side objects is missing an id
-        const incomingByHash =
-          idKey && currentItems.some((item) => !(item as any)[idKey]) && groupBy(incomingItems, hashWithoutId);
+        const incomingByContent =
+          idKey && currentItems.some((item) => !(item as any)[idKey]) && groupBy(incomingItems, hashByContent);
 
         // Watch for deletions
         const hasOpKey = Object.keys(listConfig.config).includes("op");
@@ -261,17 +271,21 @@ export function newListFieldState<T, K extends keyof T, U>(
         for (const currentItem of currentItems) {
           const childState = rowMap.get(currentItem)!; // We'll always have a child state for `currentItems`
           // Try to find a matching item in the incoming data
-          const hash = hashItem(currentItem);
-          const match = (incomingById.get(hash)?.[0] ?? (!!incomingByHash && incomingByHash?.get(hash)?.[0])) as
-            | U
-            | undefined;
+          const hash = hashById(currentItem);
+          const match = (incomingById.get(hash)?.[0] ??
+            // Only if we don't have `book[id]` set, look for a match based on our content
+            (!!idKey &&
+              !(currentItem as any)[idKey] &&
+              !!incomingByContent &&
+              // If we don't have an id, our `hash` variable will already be the `hashByContent`, so we can reuse it
+              incomingByContent?.get(hash)?.[0])) as U | undefined;
           if (match) {
             // Defer to set to handle not nuking WIP changes
             childState.set(match, opts);
             mergedItems.push(childState.value);
-            // Once matched, we don't this to be an addedRow anymore
+            // Once matched, we don't want this to be an addedRow anymore
             addedRows.delete(currentItem);
-          } else if (!childState.dirty && !addedRows.has(currentItem)) {
+          } else if (!childState.dirty && !childState.isNewEntity && !addedRows.has(currentItem)) {
             // Local is not dirty/added, and it's not upstream, so let it get removed
           } else if (hasOpKey && (currentItem as any).op === "delete") {
             // We were locally marked as deleted, and not finding a match is the server acking that we're gone
@@ -291,7 +305,7 @@ export function newListFieldState<T, K extends keyof T, U>(
         for (const incomingItem of incomingItems) {
           // Look for both `incoming.id` and the incoming-sans-id for new entities
           const match =
-            currentById.get(hashItem(incomingItem))?.[0] || currentById.get(hashWithoutId(incomingItem))?.[0];
+            currentById.get(hashById(incomingItem))?.[0] || currentById.get(hashByContent(incomingItem))?.[0];
           if (!match) {
             // New item from server, add it
             const childState = getOrCreateChildState(incomingItem, opts);

--- a/src/formState.test.tsx
+++ b/src/formState.test.tsx
@@ -324,6 +324,85 @@ describe("formState", () => {
     expect(state.books.dirty).toBe(false);
   });
 
+  it("list value can refresh and merge grand children that were added", () => {
+    // Given a list field that is currently populated with 1 child w/1 grandchild
+    const a1: AuthorInput = {
+      id: "a:1",
+      books: [{ id: "b:1", title: "b1", reviews: [{ id: "r:1", rating: 5 }] }],
+    };
+    const config = f.config<AuthorInput>({
+      id: f.value(),
+      books: f.list({
+        id: f.value(),
+        title: f.value().req(),
+        reviews: f.list({ id: f.value(), rating: f.value().req() }),
+      }),
+    });
+    const state = createObjectState<AuthorInput>(config, a1);
+    // When we add a new book with two ratings
+    state.books.add({ title: "b2", reviews: [{ rating: 4 }, { rating: 3 }] });
+    // When we refresh but only the 1st review grandchild existed when we auto-saved
+    state.set(
+      {
+        books: [
+          { id: "b:1", title: "b1" },
+          {
+            id: "b:2",
+            title: "b2",
+            reviews: [{ id: "r:2", rating: 4 }],
+          },
+        ],
+      },
+      { refreshing: true } as InternalSetOpts,
+    );
+    // Then we still have two books
+    expect(state.books.value).toEqual([
+      {
+        id: "b:1",
+        title: "b1",
+        reviews: [{ id: "r:1", rating: 5 }],
+      },
+      {
+        id: "b:2",
+        title: "b2",
+        // And we stitched together the ack-d 1st review (now with an id assigned) and the 2nd WIP review
+        reviews: [{ id: "r:2", rating: 4 }, { rating: 3 }],
+      },
+    ]);
+    // And we're still dirty
+    expect(state.books.dirty).toBe(true);
+    expect(state.books.rows[0].dirty).toBe(false);
+    expect(state.books.rows[1].dirty).toBe(true);
+    expect(state.books.rows[1].reviews.rows[0].dirty).toBe(false);
+    expect(state.books.rows[1].reviews.rows[1].dirty).toBe(false);
+    expect(state.books.rows[1].reviews.dirty).toBe(true);
+
+    // Until the 2nd auto-save completes
+    state.set(
+      {
+        books: [
+          { id: "b:1", title: "b1" },
+          {
+            id: "b:2",
+            title: "b2",
+            reviews: [
+              { id: "r:2", rating: 4 },
+              { id: "r:3", rating: 3 },
+            ],
+          },
+        ],
+      },
+      { refreshing: true } as InternalSetOpts,
+    );
+    // Then we stitch together the 2nd review as well
+    expect(state.books.value).toMatchObject([
+      { id: "b:1" },
+      { id: "b:2", reviews: [{ id: "r:2" }, { id: "r:3", rating: 3 }] },
+    ]);
+    // And we're no longer dirty
+    expect(state.books.dirty).toBe(false);
+  });
+
   it("list value can observe changes", () => {
     const b1: BookInput = { title: "t1" };
     const a1: AuthorInput = { firstName: "a1", books: [b1] };

--- a/src/formStateDomain.ts
+++ b/src/formStateDomain.ts
@@ -37,6 +37,12 @@ export interface BookInput {
   delete?: boolean | null | undefined;
   isPublished?: boolean;
   op?: "include" | "delete" | "remove";
+  reviews?: ReviewInput[];
+}
+
+export interface ReviewInput {
+  id?: string | null | undefined;
+  rating?: number | null | undefined;
 }
 
 export interface DeweyDecimalClassification {

--- a/src/useFormState.test.tsx
+++ b/src/useFormState.test.tsx
@@ -185,11 +185,18 @@ describe("useFormState", () => {
       };
       const data2 = {
         id: "a:1",
-        firstName: "f2",
+        firstName: "f2", // we'll have a local WIP change
         lastName: "l2",
-        address: { id: "address:1", street: "s2", city: "c2" },
+        address: {
+          id: "address:1",
+          street: "s2", // we'll have a local WIP change
+          city: "c2",
+        },
         books: [
-          { id: "b:1", title: "a2" },
+          {
+            id: "b:1",
+            title: "a2", // we'll have a local WIP change
+          },
           { id: "b:2", title: "b2" },
           { id: "b:3", title: "b3" },
         ],


### PR DESCRIPTION
Previously our hueristic of:

This local book1 (without an id) sure looks like this remote book1 that does have an id ==> merge them

Used "all non-id keys" (we can't use id b/c we know its not set yet for our local book) to determine "are these the same effective book".

However if the book also had grandchild reviews, where the local book had an id-less/unsaved review, and the incoming book does have that review (but now with an id), we had been including the "reviews" fields in the "diff of local book vs. remote book", so these would look like "different books".

Now we only compare local/remote entities on "content keys" were are both non-id & value-only keys, so things like title, rating, name, etc, and we don't include "complex children" (either nested type=object or type=list children).

This basically matches the heuristic a programmer would write by hand, i.e. "these two books are 'the same' if they have the same title", and they probably wouldn't bother checking "are the child reviews also 'the same'" because those child keys aren't really part of "the identity" of the row.