### PR TITLE
feat: Add formState.update for acking responses.

### DIFF
--- a/src/fields/objectField.ts
+++ b/src/fields/objectField.ts
@@ -321,16 +321,18 @@ export function newObjectState<T, P = any>(
       getFields(this).forEach((f) => f.revertChanges());
     },
 
-    // Saves all current values into _originalValue
+    // Saves all current values into _originalValue.
+    // Deprecated: use formState.update(ackedServerValue) so saved changes are audited field-by-field.
     commitChanges() {
       if (this._isAutoSaving) {
         // `commitChanges` will mark all WIP changes as committed, which might drop changes if there
         // is an auto-save in-flight, and the user made more changes, that are waiting for their turn
         // on the next auto-save request.
         //
-        // Instead of doing a form-wide "all changes are committed", instead autosave forms should use
-        // init.map/input to have the server's latest results updated within the form, which will then
-        // selectively "un-dirty"/commit the just-saved data, but keep the "still-dirty" WIP data alone.
+        // Instead of doing a form-wide "all changes are committed", autosave forms should use
+        // formState.update(ackedServerValue), or init.map/input, to apply the server's latest results
+        // within the form. That selectively "un-dirty"/commits the just-saved data, but keeps the
+        // "still-dirty" WIP data alone.
         throw new Error(
           "When using autoSave, you should not manually call commitChanges, instead have init.map/input update the form state",
         );

--- a/src/fields/valueField.ts
+++ b/src/fields/valueField.ts
@@ -42,7 +42,13 @@ export interface FieldState<V> {
   set(value: V, opts?: SetOpts): void;
   /** Reverts back to the original value and resets dirty/touched. */
   revertChanges(): void;
-  /** Accepts the current changed value (if any) as the original and resets dirty/touched. */
+  /**
+   * Accepts the current changed value (if any) as the original and resets dirty/touched.
+   *
+   * @deprecated Use `formState.update(ackedServerValue)` instead. `commitChanges` marks all current
+   * changes as saved, which risks discarding a user's in-flight edits. Updating from the server ack gives
+   * form-state a field-by-field audit of which changes were successfully saved.
+   */
   commitChanges(): void;
   /** Creates a new FieldState with a transformation of the value, i.e. string to int, or feet to inches. */
   adapt<V2>(adapter: ValueAdapter<V, V2>): FieldState<V2>;

--- a/src/useFormState.test.tsx
+++ b/src/useFormState.test.tsx
@@ -321,6 +321,75 @@ describe("useFormState", () => {
     expect(r.firstName.textContent).toEqual("F2");
   });
 
+  it("can immediately update from a server ack before init input rerenders", async () => {
+    type FormValue = Pick<AuthorInput, "firstName" | "lastName">;
+    type ServerAuthor = { legalFirstName: string; legalLastName: string };
+    const config: ObjectConfig<FormValue> = {
+      firstName: { type: "value" },
+      lastName: { type: "value" },
+    };
+    const initialAuthor: ServerAuthor = { legalFirstName: "First", legalLastName: "Last" };
+    const savedAuthor: ServerAuthor = { legalFirstName: "Saved", legalLastName: "Author" };
+
+    function TestComponent() {
+      const form = useFormState({
+        config,
+        init: { input: initialAuthor, map: mapServerAuthor },
+      });
+
+      function makeLocalChanges() {
+        form.firstName.set("Saved");
+        form.lastName.set("Author");
+      }
+
+      function saveWithoutUpdating() {
+        noop(form.changedValue);
+      }
+
+      function saveAndUpdate() {
+        noop(form.changedValue);
+        form.update(savedAuthor);
+      }
+
+      return (
+        <Observer>
+          {() => (
+            <div>
+              <div data-testid="firstName">{form.firstName.value}</div>
+              <div data-testid="lastName">{form.lastName.value}</div>
+              <div data-testid="dirty">{String(form.dirty)}</div>
+              <button data-testid="makeLocalChanges" onClick={makeLocalChanges} />
+              <button data-testid="saveWithoutUpdating" onClick={saveWithoutUpdating} />
+              <button data-testid="saveAndUpdate" onClick={saveAndUpdate} />
+            </div>
+          )}
+        </Observer>
+      );
+    }
+
+    const r = await render(<TestComponent />);
+    expect(r.firstName.textContent).toEqual("First");
+    expect(r.lastName.textContent).toEqual("Last");
+    expect(r.dirty.textContent).toEqual("false");
+
+    click(r.makeLocalChanges);
+    expect(r.firstName.textContent).toEqual("Saved");
+    expect(r.lastName.textContent).toEqual("Author");
+    expect(r.dirty.textContent).toEqual("true");
+
+    click(r.saveWithoutUpdating);
+    expect(r.dirty.textContent).toEqual("true");
+
+    click(r.saveAndUpdate);
+    expect(r.firstName.textContent).toEqual("Saved");
+    expect(r.lastName.textContent).toEqual("Author");
+    expect(r.dirty.textContent).toEqual("false");
+
+    function mapServerAuthor(input: ServerAuthor): FormValue {
+      return { firstName: input.legalFirstName, lastName: input.legalLastName };
+    }
+  });
+
   it("can accept new data while read only", async () => {
     // Given a component
     function TestComponent() {

--- a/src/useFormState.ts
+++ b/src/useFormState.ts
@@ -1,7 +1,7 @@
 import { isPlainObject } from "is-plain-object";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ObjectConfig } from "src/config";
-import { ObjectState, createObjectState } from "src/fields/objectField";
+import { type ObjectConfig } from "src/config";
+import { type ObjectState, type ObjectStateInternal, createObjectState } from "src/fields/objectField";
 import { initValue, isInput, isQuery } from "./utils";
 
 // A structural match for useQuery
@@ -75,6 +75,18 @@ export type UseFormStateOpts<T, I> = {
   autoSave?: (state: ObjectState<T>) => Promise<unknown>;
 };
 
+export type FormObjectState<T, I> = ObjectState<T> & {
+  /**
+   * Refreshes the form with a server-acked value, i.e. `form.update(savedAuthor)`.
+   *
+   * This is intended for save callbacks that need `form.dirty` to become `false` immediately, before the
+   * normal query/cache refresh has a chance to rerender `useFormState`. Pass the value returned by the
+   * server so the form can map it through `init.map` and then do a field-by-field refresh of only the
+   * changes the server has acknowledged.
+   */
+  update(input: Exclude<I, null | undefined>): void;
+};
+
 // If the user's autoSave hook makes some last-minute `.set` calls to sneak
 // in some business logic right before their GraphQL mutation call, ignore it
 // so that we don't infinite loop.
@@ -87,12 +99,15 @@ let pendingAutoSave = false;
 /**
  * Creates a formState instance for editing in a form.
  */
-export function useFormState<T, I>(opts: UseFormStateOpts<T, I>): ObjectState<T> {
+export function useFormState<T, I>(opts: UseFormStateOpts<T, I>): FormObjectState<T, I> {
   const { config, init, addRules, readOnly = false, loading, autoSave } = opts;
 
   // Use a ref so our memo'ized `onBlur` always see the latest value
   const autoSaveRef = useRef<((state: ObjectState<T>) => void) | undefined>(autoSave);
   autoSaveRef.current = autoSave;
+  // Use a ref so our memo'ized `update` always sees the latest init/map
+  const initRef = useRef<UseFormStateOpts<T, I>["init"]>(init);
+  initRef.current = init;
 
   const firstRunRef = useRef<boolean>(true);
   // This is a little weird, but we need to know ahead of time, before the form useMemo, if we're working with classes/mobx proxies
@@ -159,7 +174,18 @@ export function useFormState<T, I>(opts: UseFormStateOpts<T, I>): ObjectState<T>
         }
       }
       const value = firstRunRef.current ? firstInitValue : initValue(config, init);
-      const form = createObjectState(config, value, { maybeAutoSave });
+      const form = createObjectState(config, value, { maybeAutoSave }) as FormObjectState<T, I>;
+      form.update = function update(input) {
+        const init = initRef.current;
+        const updateInit = isInput(init)
+          ? { ...init, input }
+          : isQuery(init)
+            ? { input, map: init.map, ifUndefined: init.ifUndefined }
+            : { input };
+        (form as unknown as ObjectStateInternal<T>).set(initValue(config, updateInit), {
+          refreshing: true,
+        });
+      };
       form.readOnly = readOnly;
       setLoading(form, opts);
       // The identity of `addRules` is not stable, but assume that it is for better UX.


### PR DESCRIPTION
This allows an onSave callback to immediately navigate, i.e. after an `await saveAuthor` mutation has finished, and not get stopped by a well-meaning `formState.dirty` triggering a "you have unsaved changes".