### PR TITLE
fix: export FormObjectState & fix local WIP array changes

### DIFF
--- a/src/fields/valueField.ts
+++ b/src/fields/valueField.ts
@@ -249,7 +249,10 @@ export function newValueFieldState<T, K extends keyof T>(
         //   is exactly acking our change, or
         // - the user hasn't made any changes since `.changedValue` was put on the wire, i.e. the
         //   server received our value, but wanted to change it.
-        const keepLocalWipChange = this.value !== value && !isAckingUnset && !acceptServerAck;
+        // Compare by content (not `!==`) so array/list-of-primitive values are treated as acked when
+        // the server returns the same contents in a new array instance (otherwise the field would
+        // stay dirty forever, since reference equality never holds for a fresh array).
+        const keepLocalWipChange = !areEqual(this.value, value, strictOrder) && !isAckingUnset && !acceptServerAck;
         if (keepLocalWipChange) return;
       } else if (computed && (opts.resetting || opts.refreshing)) {
         // Computeds can't be either reset or refreshed

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,6 @@ export { type ListFieldState } from "src/fields/listField";
 export { createObjectState, type Fragment, type ObjectState, fragment } from "src/fields/objectField";
 export { type FieldState, type ValueAdapter } from "src/fields/valueField";
 export { required, type Rule } from "src/rules";
-export { useFormState } from "src/useFormState";
+export { type FormObjectState, useFormState } from "src/useFormState";
 export { useFormStates } from "src/useFormStates";
 export { type ObjectConfig } from "./config";

--- a/src/useFormState.test.tsx
+++ b/src/useFormState.test.tsx
@@ -390,6 +390,40 @@ describe("useFormState", () => {
     }
   });
 
+  it("becomes clean when update acks an array value with the same contents", async () => {
+    // Given a form with an array-of-primitives value field
+    type FormValue = { colors: string[] };
+    const config: ObjectConfig<FormValue> = { colors: { type: "value" } };
+
+    function TestComponent() {
+      const form = useFormState({ config, init: { input: { colors: ["red", "green", "blue"] } } });
+      // Note: we deliberately do not read `form.changedValue` (the way an auto-save would), so the only
+      // thing that can let `update` accept the server value is content equality, not the changedValue hint.
+      return (
+        <Observer>
+          {() => (
+            <div>
+              <div data-testid="colors">{(form.colors.value ?? []).join(",")}</div>
+              <div data-testid="dirty">{String(form.dirty)}</div>
+              <button data-testid="edit" onClick={() => form.colors.set(["red", "green"])} />
+              <button data-testid="saveAndUpdate" onClick={() => form.update({ colors: ["red", "green"] })} />
+            </div>
+          )}
+        </Observer>
+      );
+    }
+    const r = await render(<TestComponent />);
+    expect(r.dirty.textContent).toEqual("false");
+    // When the user edits the array
+    click(r.edit);
+    expect(r.dirty.textContent).toEqual("true");
+    // And the server acks the same contents in a brand-new array instance
+    click(r.saveAndUpdate);
+    // Then the form is clean (we don't get stuck dirty on array reference inequality)
+    expect(r.colors.textContent).toEqual("red,green");
+    expect(r.dirty.textContent).toEqual("false");
+  });
+
   it("can accept new data while read only", async () => {
     // Given a component
     function TestComponent() {


### PR DESCRIPTION
- Follow up of https://github.com/homebound-team/form-state/pull/135 to export `FormObjectState` type
- Fix WIP local array changes comparison